### PR TITLE
Allow multiple model files with distinct include syntax

### DIFF
--- a/CharLib.py
+++ b/CharLib.py
@@ -68,7 +68,8 @@ def execute_lib(characterizer: Characterizer, library_dir):
             with open(file, 'r') as f:
                 config = yaml.safe_load(f)
                 f.close()
-        except yaml.YAMLError:
+        except yaml.YAMLError as e:
+            print(e)
             print(f'Skipping "{str(file)}": file contains invalid YAML')
             continue
         if config.keys() >= {'settings', 'cells'}:

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ osu350_lib: CharLib.py test/osu350/osu350.yml
 
 gf180: CharLib.py
 	$(shell test/gf180/fetch_spice.sh)
+	python3 CharLib.py -l test/gf180
 
 clean:
 	rm -rf __pycache__

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,12 @@
 # Makefile
 
-all:	osu350_lib
+all:	osu350 gf180
 
-setup:
-	mkdir -p ./work
-
-gencmd: setup
-	python3 gen_cmd.py
-
-osu350:	CharLib.py test/osu350/OSU350.cmd setup
-	$(shell test/osu350/fetch_spice.sh)
-	python3 CharLib.py -b test/osu350/OSU350.cmd
-
-osu350_lib: CharLib.py test/osu350/osu350.yml
+osu350: CharLib.py test/osu350/osu350.yml
 	$(shell test/osu350/fetch_spice.sh)
 	python3 CharLib.py -l test/osu350
 
-gf180: CharLib.py
+gf180: CharLib.py test/gf180/gf180.yml
 	$(shell test/gf180/fetch_spice.sh)
 	python3 CharLib.py -l test/gf180
 

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -93,6 +93,9 @@ These keys may optionally be included to provide additional cell documentation o
 
 * `area`: The physical area occupied by the cell layout. Defaults to 0 if omitted.
 * `models`: A sequence of paths to the spice models for transistors used in this cell's netlist. If omitted, CharLib assumes each cell has no dependencies.
+	* Using the syntax `path/to/file` will result in `.include path/to/file` in SPICE simulations.
+	* Using the syntax `path/to/dir` will allow CharLib to search the directory for subcircuits used in a particular cell and include them using `.include path/to/dir/file`.
+	* Using the syntax `path/to/file section` will result in `.lib path/to/file section` in SPICE simulations.
 * `test_vectors`: A sequence of test vectors for simulation. If omitted, test vectors are instead generated based on the cell's `functions`.
     * Each test vector should be in the format `[clk, set (if present), reset (if present), flop1, ..., flopK, in1, ..., inN, out1, ..., outM]` (omit `clk, set, reset, flop1, ..., flopK` for combinational cells).
     * Including the `test_vectors` key can result in significant reductions in CharLib simulation times. If you already know the test conditions that will reveal critical paths for your cells, you should include them as test vectors under this key.
@@ -283,7 +286,7 @@ settings:
             voltage:    3.3
     cell_defaults:
         models:  
-            - gf180_temp/models/sm141064.ngspice typical
+            - gf180_temp/models/sm141064.ngspice typical # This syntax tells CharLib to use the '.lib file section' syntax for this model
             - gf180_temp/models/design.ngspice
         slews:  [0.015, 0.08, 0.4]
         loads:  [0.06, 1.2]

--- a/liberty/LibrarySettings.py
+++ b/liberty/LibrarySettings.py
@@ -25,11 +25,11 @@ def str_to_bool(value: str) -> bool:
 class LibrarySettings:
     def __init__(self, **kwargs):
         # Behavioral settings
-        self._lib_name = kwargs.get('lib_name', 'unnamed_lib')
+        self.lib_name = str(kwargs.get('lib_name', 'unnamed_lib'))
         self._dotlib_name = kwargs.get('dotlib_name')
         self._verilog_name = kwargs.get('verilog_name')
-        self._cell_name_suffix = kwargs.get('cell_name_suffix', '')
-        self._cell_name_prefix = kwargs.get('cell_name_prefix', '')
+        self.cell_name_suffix = str(kwargs.get('cell_name_suffix', ''))
+        self.cell_name_prefix = str(kwargs.get('cell_name_prefix', ''))
         self._work_dir = Path(kwargs.get('work_dir', 'work'))
         self._results_dir = Path(kwargs.get('results_dir', 'results'))
         self._run_sim = kwargs.get('run_simulation', True)
@@ -62,11 +62,6 @@ class LibrarySettings:
         self._operating_conditions = kwargs.get('operating_conditions', 'typical')
         self._delay_model = kwargs.get('delay_model', 'table_lookup')
         self.cell_defaults = kwargs.get('cell_defaults', {})
-
-        # TODO: Deprecate these settings
-        self._suppress_msg = False
-        self._suppress_sim_msg = False
-        self._suppress_debug_msg = False
 
     def __str__(self) -> str:
         lines = []
@@ -138,17 +133,6 @@ class LibrarySettings:
             raise ValueError(f'Invalid value for simulator: {value}')
 
     @property
-    def lib_name(self) -> str:
-        return self._lib_name
-
-    @lib_name.setter
-    def lib_name(self, value: str):
-        if value is not None and len(value) > 0:
-            self._lib_name = value
-        else:
-            raise ValueError(f'Invalid value for lib_name: {value}')
-
-    @property
     def dotlib_name(self) -> str:
         if self._dotlib_name is None:
             return self.lib_name + '.lib'
@@ -179,28 +163,6 @@ class LibrarySettings:
             self._verilog_name = str(value)
         else:
             raise ValueError(f'Invalid value for verilog_name: {value}')
-
-    @property
-    def cell_name_suffix(self) -> str:
-        return self._cell_name_suffix
-
-    @cell_name_suffix.setter
-    def cell_name_suffix(self, value: str):
-        if value is not None and len(value) > 0:
-            self._cell_name_suffix = value
-        else:
-            raise ValueError(f'Invalid value for cell_name_suffix: {value}')
-
-    @property
-    def cell_name_prefix(self) -> str:
-        return self._cell_name_prefix
-
-    @cell_name_prefix.setter
-    def cell_name_prefix(self, value: str):
-        if value is not None and len(value) > 0:
-            self._cell_name_prefix = value
-        else:
-            raise ValueError(f'Invalid value for cell_name_suffix: {value}')
 
     @property
     def process(self) -> str:
@@ -379,27 +341,3 @@ class LibrarySettings:
 
     def set_exported(self):
         self._is_exported = True
-
-    @property
-    def suppress_message(self) -> bool:
-        return self._suppress_msg
-    
-    @suppress_message.setter
-    def suppress_message(self, value: str):
-        self._suppress_msg = str_to_bool(value)
-
-    @property
-    def suppress_sim_message(self) -> bool:
-        return self._suppress_sim_msg
-
-    @suppress_sim_message.setter
-    def suppress_sim_message(self, value: str):
-        self._suppress_sim_msg = str_to_bool(value)
-    
-    @property
-    def suppress_debug_message(self) -> bool:
-        return self._suppress_debug_msg
-
-    @suppress_debug_message.setter
-    def suppress_debug_message(self, value: str):
-        self._suppress_debug_msg = str_to_bool(value)

--- a/test/gf180/fetch_spice.sh
+++ b/test/gf180/fetch_spice.sh
@@ -8,8 +8,8 @@ CELL_COMMIT='df1d8ec95b'
 CELL_DIR='globalfoundries-pdk-libs-gf180mcu_osu_sc/gf180mcu_osu_sc_gp12t3v3/cells'
 
 # Source for fetching models
-MODEL_SOURCE='https://github.com/google/globalfoundries-pdk-libs-gf180mcu_fd_pr/blob/main/models/ngspice/sm141064.ngspice'
-MODEL_FILENAME='sm141064.spice'
+MODEL_SOURCE='https://raw.githubusercontent.com/google/globalfoundries-pdk-libs-gf180mcu_fd_pr/main/models/ngspice/sm141064.ngspice'
+MODEL_FILENAME='sm141064.ngspice'
 
 mkdir -p $TARGET_DIR
 pushd $TARGET_DIR > /dev/null
@@ -22,6 +22,7 @@ cd ..
 for CELL_FILE in `find "$CELL_DIR" -type f -name "*.spice"`
 do
     cp $CELL_FILE $TARGET_DIR/.
+    sed -i 's/fet_03p3/mos_3p3_t/' $TARGET_DIR/$CELL_FILE
 done
 rm -rf globalfoundries-pdk-libs-gf180mcu_osu_sc/
 

--- a/test/gf180/fetch_spice.sh
+++ b/test/gf180/fetch_spice.sh
@@ -1,32 +1,37 @@
 #!/bin/bash
 
-TARGET_DIR=${PWD}'/gf180_spice_temp'
+TARGET_DIR=${PWD}'/gf180_temp'
 
 # Sources for fetching cells
-CELL_GIT_SOURCE='https://github.com/stineje/globalfoundries-pdk-libs-gf180mcu_osu_sc'
+CELL_GIT_SRC='https://github.com/stineje/globalfoundries-pdk-libs-gf180mcu_osu_sc'
 CELL_COMMIT='df1d8ec95b'
 CELL_DIR='globalfoundries-pdk-libs-gf180mcu_osu_sc/gf180mcu_osu_sc_gp12t3v3/cells'
 
 # Source for fetching models
-MODEL_SOURCE='https://raw.githubusercontent.com/google/globalfoundries-pdk-libs-gf180mcu_fd_pr/main/models/ngspice/sm141064.ngspice'
-MODEL_FILENAME='sm141064.ngspice'
+MODEL_SRC='https://raw.githubusercontent.com/google/globalfoundries-pdk-libs-gf180mcu_fd_pr/main/models/ngspice'
+MODEL1_FILENAME='sm141064.ngspice'
+MODEL2_FILENAME='design.ngspice'
 
-mkdir -p $TARGET_DIR
+rm -rf $TARGET_DIR
+mkdir $TARGET_DIR
 pushd $TARGET_DIR > /dev/null
+mkdir cells
+mkdir models
 
 # Fetch cells from a tested commit hash
-git clone $CELL_GIT_SOURCE
+git clone $CELL_GIT_SRC
 cd globalfoundries-pdk-libs-gf180mcu_osu_sc/
 git checkout $CELL_COMMIT
 cd ..
 for CELL_FILE in `find "$CELL_DIR" -type f -name "*.spice"`
 do
-    cp $CELL_FILE $TARGET_DIR/.
-    sed -i 's/fet_03p3/mos_3p3_t/' $TARGET_DIR/$CELL_FILE
+    sed -i 's/fet_03p3/mos_3p3/' $CELL_FILE
+    cp $CELL_FILE $TARGET_DIR/cells/.
 done
 rm -rf globalfoundries-pdk-libs-gf180mcu_osu_sc/
 
 # Fetch transistor models
-curl -s $MODEL_SOURCE > $MODEL_FILENAME
+curl -s $MODEL_SRC/$MODEL1_FILENAME > models/$MODEL1_FILENAME
+curl -s $MODEL_SRC/$MODEL2_FILENAME > models/$MODEL2_FILENAME
 
 popd > /dev/null

--- a/test/gf180/gf180.yml
+++ b/test/gf180/gf180.yml
@@ -24,19 +24,21 @@ settings:
             name:       VNW
             voltage:    3.3
     cell_defaults:
-        model:  gf180_spice_temp/sm141064.spice
+        models:  
+            - gf180_temp/models/sm141064.ngspice typical
+            - gf180_temp/models/design.ngspice
         slews:  [0.015, 0.08, 0.4]
         loads:  [0.06, 1.2]
         simulation_timestep: auto
         plots:  none
 cells:
     gf180mcu_osu_sc_gp12t3v3__inv_1:
-        netlist:    gf180_spice_temp/gf180mcu_osu_sc_gp12t3v3__inv_1.spice
+        netlist:    gf180_temp/cells/gf180mcu_osu_sc_gp12t3v3__inv_1.spice
         inputs:     [A]
         outputs:    ['Y']
         functions:  [Y=~A]
     gf180mcu_osu_sc_gp12t3v3__and2_1:
-        netlist:    gf180_spice_temp/gf180mcu_osu_sc_gp12t3v3__and2_1.spice
+        netlist:    gf180_temp/cells/gf180mcu_osu_sc_gp12t3v3__and2_1.spice
         inputs:     [A,B]
         outputs:    ['Y']
         functions:  [Y=A&B]

--- a/test/gf180/gf180.yml
+++ b/test/gf180/gf180.yml
@@ -1,0 +1,42 @@
+settings:
+    lib_name:           GF180
+    cell_name_prefix:   _V1
+    cell_name_suffix:   GF180_
+    units:
+        voltage:        V
+        capacitance:    pF
+        resistance:     kOhm
+        current:        uA
+        leakage_power:  nW
+        energy:         fJ
+        time:           ns
+    named_nodes:
+        vdd:
+            name:       VDD
+            voltage:    3.3
+        vss:
+            name:       VSS
+            voltage:    0
+        pwell:
+            name:       VPW
+            voltage:    0
+        nwell:
+            name:       VNW
+            voltage:    3.3
+    cell_defaults:
+        model:  gf180_spice_temp/sm141064.spice
+        slews:  [0.015, 0.08, 0.4]
+        loads:  [0.06, 1.2]
+        simulation_timestep: auto
+        plots:  none
+cells:
+    gf180mcu_osu_sc_gp12t3v3__inv_1:
+        netlist:    gf180_spice_temp/gf180mcu_osu_sc_gp12t3v3__inv_1.spice
+        inputs:     [A]
+        outputs:    ['Y']
+        functions:  [Y=~A]
+    gf180mcu_osu_sc_gp12t3v3__and2_1:
+        netlist:    gf180_spice_temp/gf180mcu_osu_sc_gp12t3v3__and2_1.spice
+        inputs:     [A,B]
+        outputs:    ['Y']
+        functions:  [Y=A&B]

--- a/test/osu350/osu350.yml
+++ b/test/osu350/osu350.yml
@@ -2,11 +2,6 @@ settings:
     lib_name:           OSU350
     cell_name_prefix:   _V1
     cell_name_suffix:   OSU350_
-    work_dir:           work
-    export_lib:         yes
-    export_cmd:         no
-    run_simulation:     yes
-    multithreaded:      no
     units:
         voltage:        V
         capacitance:    pF
@@ -29,7 +24,7 @@ settings:
             name:       VNW
             voltage:    3.3
     cell_defaults:
-        model: test/osu350/model.sp
+        models: [test/osu350/model.sp]
         # slews: [0.015, 0.04, 0.08, 0.2, 0.4]
         # loads: [0.06, 0.18, 0.42, 0.6, 1.2]
         slews: [0.015, 0.08, 0.4]
@@ -44,7 +39,7 @@ settings:
                 highest:    1
                 lowest:     0.01
                 timestep:   0.005
-        plots: [io, delay]
+        #plots: [io, delay]
 cells:
     INVX1:
         netlist:    osu350_spice_temp/INVX1.sp


### PR DESCRIPTION
Enables users to provide multiple spice files to source subcircuit and model definitions, using distinct syntax for `.inc` and `.lib` calls. This also enables GF180 support, since it requires both of the following (or a variation thereof):

```
.include ../models/design.ngspice
.lib ../models/sm141064.ngspice typical
```

Testing was done against the existing OSU350 configuration and a new GF180 test config (see test/gf180/gf180.yml below).

Fixes #9 