### PR TITLE
Fix CLI flag behavior and improve documentation

### DIFF
--- a/charlib/characterizer/run.py
+++ b/charlib/characterizer/run.py
@@ -82,14 +82,14 @@ def run_charlib(args):
         raise FileNotFoundError(f'Unable to locate a YAML file containing configuration settings in {library_dir} or its subdirectories.')
     print(f'Reading configuration found in "{str(file)}"')
 
-    # Override settings with command line settings
+    # OR settings with command line options
     settings = config['settings']
-    settings['debug'] = args.debug
-    settings['multithreaded'] = args.multithreaded
     cells = config['cells']
 
     # Read in library settings
     characterizer = Characterizer(**settings)
+    characterizer.settings.debug = characterizer.settings.debug or args.debug
+    characterizer.settings.use_multithreaded = characterizer.settings.use_multithreaded or args.multithreaded
     logger = Logging.setup_logging(logging_level='ERROR')
 
     # Read cells

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -1,6 +1,6 @@
 # CharLib YAML Configuration
 
-When running in automatic mode, CharLib requires a YAML file with configuration settings to be present in the specified library directory. This document describes the key-value pairs that CharLib expects to find in that file.
+CharLib requires a YAML file with configuration settings to be present in the specified library directory. This document describes the key-value pairs that CharLib expects to find in that file.
 
 ## Library and Simulation Settings
 Library and characterization settings are specified as key-value pairs under the `settings` key.
@@ -45,6 +45,8 @@ These keys may optionally be included to adjust CharLib behavior:
 
 * `multithreaded`: A boolean which tells CharLib whether to dispatch jobs to multiple threads for asynchronous execution. Defaults to True.
 * `results_dir`: The directory to use for exporting characterization results. If omitted, CharLib creates a `results` directory in the current folder.
+* `debug`: A boolean which tells CharLib to display debug messages and store simulation SPICE files. Defaults to False.
+* `debug_dir`: The directory to use when storing simulation debug SPICE files. Defaults to `debug`.
 
 ## Cells
 Specific cells to characterize are specified as entries under the `cells` key.
@@ -65,6 +67,8 @@ Each cell entry is a dictionary with (at minimum) the following required keys:
 * `simulation_timestep`: The simulation timestep.
 
 Several of these keys can easily be omitted from cell entries by instead specifying them in the `settings.cell_defaults` dictionary. Any key-value pairs in `settings.cell_defaults` are automatically merged into each cell entry when adding the cell to the characterizer. If a key appears in a cell's entry and in `cell_defaults`, the value in the cell entry overrides the value from `cell_defaults`.
+
+> If you prefer to keep individual cell configurations separate from your toplevel CharLib configuration file, YAML files for individual cells may be specified using the syntax `cell_name: relative/path/to/cell/from/current/dir`. This gives you the option of, for example, storing your cell YAML files in the same place as your cell SPICE models.
 
 ### Additional Required Keys for Sequential Cell Entries
 Sequential Cell entries must specify the following key-value pairs in addition to the above:
@@ -176,7 +180,7 @@ cells:
 ```
 
 ### Example 3: OSU350 DFFSR Characterization
-```
+``` YAML
 settings:
     lib_name:           test_OSU350
     units:
@@ -221,7 +225,7 @@ cells:
 ```
 
 ### Example 4: Characterizing Multiple GF180 Cells
-```
+``` YAML
 settings:
     lib_name:           test_GF180
     units:

--- a/test/osu350/invx1.yml
+++ b/test/osu350/invx1.yml
@@ -1,0 +1,5 @@
+netlist:    osu350_spice_temp/INVX1.sp
+area:       64
+inputs:     [A]
+outputs:    ['Y']
+functions:  [Y=!A]

--- a/test/test.yml
+++ b/test/test.yml
@@ -40,6 +40,16 @@ cells:
         inputs:     [A]
         outputs:    ['Y']
         functions:  [Y=A]
+    DFFSR:
+        netlist:    osu350_spice_temp/DFFSR.sp
+        area:       704
+        clock:      posedge CLK
+        set:        negedge S
+        reset:      negedge R
+        inputs:     [D]
+        outputs:    [Q]
+        flops:      [P0002,P0003]
+        functions:  [Q<=D]
     INVX1:
         netlist:    osu350_spice_temp/INVX1.sp
         area:       64

--- a/test/test.yml
+++ b/test/test.yml
@@ -28,55 +28,50 @@ settings:
         setup_time_range: [0.001, 1]
         hold_time_range: [0.001, 1]
 cells:
-    AND2X1:
-        netlist:    osu350_spice_temp/AND2X1.sp
-        area:       128
-        inputs:     [A,B]
-        outputs:    ['Y']
-        functions:  [Y=A&B]
-    BUFX2:
-        netlist:    osu350_spice_temp/BUFX2.sp
-        area:       96
-        inputs:     [A]
-        outputs:    ['Y']
-        functions:  [Y=A]
-    DFFSR:
-        netlist:    osu350_spice_temp/DFFSR.sp
-        area:       704
-        clock:      posedge CLK
-        set:        negedge S
-        reset:      negedge R
-        inputs:     [D]
-        outputs:    [Q]
-        flops:      [P0002,P0003]
-        functions:  [Q<=D]
-    INVX1:
-        netlist:    osu350_spice_temp/INVX1.sp
-        area:       64
-        inputs:     [A]
-        outputs:    ['Y']
-        functions:  [Y=!A]
-    NAND2X1:
-        netlist:    osu350_spice_temp/NAND2X1.sp
-        area:       96
-        inputs:     [A,B]
-        outputs:    ['Y']
-        functions:  [Y=!(A&B)]
-    NOR2X1:
-        netlist:    osu350_spice_temp/NOR2X1.sp
-        area:       96
-        inputs:     [A,B]
-        outputs:    ['Y']
-        functions:  [Y=!(A|B)]
-    OR2X1:
-        netlist:    osu350_spice_temp/OR2X1.sp
-        area:       128
-        inputs:     [A,B]
-        outputs:    ['Y']
-        functions:  [Y=A|B]
-    XNOR2X1:
-        netlist:    osu350_spice_temp/XNOR2X1.sp
-        area:       224
-        inputs:     [A,B]
-        outputs:    ['Y']
-        functions:  [Y=!(A^B)]
+    # AND2X1:
+    #     netlist:    osu350_spice_temp/AND2X1.sp
+    #     area:       128
+    #     inputs:     [A,B]
+    #     outputs:    ['Y']
+    #     functions:  [Y=A&B]
+    # BUFX2:
+    #     netlist:    osu350_spice_temp/BUFX2.sp
+    #     area:       96
+    #     inputs:     [A]
+    #     outputs:    ['Y']
+    #     functions:  [Y=A]
+    # DFFSR:
+    #     netlist:    osu350_spice_temp/DFFSR.sp
+    #     area:       704
+    #     clock:      posedge CLK
+    #     set:        negedge S
+    #     reset:      negedge R
+    #     inputs:     [D]
+    #     outputs:    [Q]
+    #     flops:      [P0002,P0003]
+    #     functions:  [Q<=D]
+    INVX1:          test/osu350/invx1.yml
+    # NAND2X1:
+    #     netlist:    osu350_spice_temp/NAND2X1.sp
+    #     area:       96
+    #     inputs:     [A,B]
+    #     outputs:    ['Y']
+    #     functions:  [Y=!(A&B)]
+    # NOR2X1:
+    #     netlist:    osu350_spice_temp/NOR2X1.sp
+    #     area:       96
+    #     inputs:     [A,B]
+    #     outputs:    ['Y']
+    #     functions:  [Y=!(A|B)]
+    # OR2X1:
+    #     netlist:    osu350_spice_temp/OR2X1.sp
+    #     area:       128
+    #     inputs:     [A,B]
+    #     outputs:    ['Y']
+    #     functions:  [Y=A|B]
+    # XNOR2X1:
+    #     netlist:    osu350_spice_temp/XNOR2X1.sp
+    #     area:       224
+    #     inputs:     [A,B]
+    #     outputs:    ['Y']
+    #     functions:  [Y=!(A^B)]

--- a/test/test.yml
+++ b/test/test.yml
@@ -28,50 +28,50 @@ settings:
         setup_time_range: [0.001, 1]
         hold_time_range: [0.001, 1]
 cells:
-    # AND2X1:
-    #     netlist:    osu350_spice_temp/AND2X1.sp
-    #     area:       128
-    #     inputs:     [A,B]
-    #     outputs:    ['Y']
-    #     functions:  [Y=A&B]
-    # BUFX2:
-    #     netlist:    osu350_spice_temp/BUFX2.sp
-    #     area:       96
-    #     inputs:     [A]
-    #     outputs:    ['Y']
-    #     functions:  [Y=A]
-    # DFFSR:
-    #     netlist:    osu350_spice_temp/DFFSR.sp
-    #     area:       704
-    #     clock:      posedge CLK
-    #     set:        negedge S
-    #     reset:      negedge R
-    #     inputs:     [D]
-    #     outputs:    [Q]
-    #     flops:      [P0002,P0003]
-    #     functions:  [Q<=D]
-    INVX1:          test/osu350/invx1.yml
-    # NAND2X1:
-    #     netlist:    osu350_spice_temp/NAND2X1.sp
-    #     area:       96
-    #     inputs:     [A,B]
-    #     outputs:    ['Y']
-    #     functions:  [Y=!(A&B)]
-    # NOR2X1:
-    #     netlist:    osu350_spice_temp/NOR2X1.sp
-    #     area:       96
-    #     inputs:     [A,B]
-    #     outputs:    ['Y']
-    #     functions:  [Y=!(A|B)]
-    # OR2X1:
-    #     netlist:    osu350_spice_temp/OR2X1.sp
-    #     area:       128
-    #     inputs:     [A,B]
-    #     outputs:    ['Y']
-    #     functions:  [Y=A|B]
-    # XNOR2X1:
-    #     netlist:    osu350_spice_temp/XNOR2X1.sp
-    #     area:       224
-    #     inputs:     [A,B]
-    #     outputs:    ['Y']
-    #     functions:  [Y=!(A^B)]
+    AND2X1:
+        netlist:    osu350_spice_temp/AND2X1.sp
+        area:       128
+        inputs:     [A,B]
+        outputs:    ['Y']
+        functions:  [Y=A&B]
+    BUFX2:
+        netlist:    osu350_spice_temp/BUFX2.sp
+        area:       96
+        inputs:     [A]
+        outputs:    ['Y']
+        functions:  [Y=A]
+    DFFSR:
+        netlist:    osu350_spice_temp/DFFSR.sp
+        area:       704
+        clock:      posedge CLK
+        set:        negedge S
+        reset:      negedge R
+        inputs:     [D]
+        outputs:    [Q]
+        flops:      [P0002,P0003]
+        functions:  [Q<=D]
+    INVX1:          invx1.yml
+    NAND2X1:
+        netlist:    osu350_spice_temp/NAND2X1.sp
+        area:       96
+        inputs:     [A,B]
+        outputs:    ['Y']
+        functions:  [Y=!(A&B)]
+    NOR2X1:
+        netlist:    osu350_spice_temp/NOR2X1.sp
+        area:       96
+        inputs:     [A,B]
+        outputs:    ['Y']
+        functions:  [Y=!(A|B)]
+    OR2X1:
+        netlist:    osu350_spice_temp/OR2X1.sp
+        area:       128
+        inputs:     [A,B]
+        outputs:    ['Y']
+        functions:  [Y=A|B]
+    XNOR2X1:
+        netlist:    osu350_spice_temp/XNOR2X1.sp
+        area:       224
+        inputs:     [A,B]
+        outputs:    ['Y']
+        functions:  [Y=!(A^B)]


### PR DESCRIPTION
Resolves #32 
Possibly related to #29 ?

- Add a DFFSR test case to test.yml
- Make command line flags work in tandem with yaml settings, so that running with `--debug` doesn't get overridden by the YAML default `debug: no`
- Test runs where some cells are defined in toplevel yaml and some cells have their own yaml files