### PR TITLE
Add several CLI options

### DIFF
--- a/charlib/characterizer/Characterizer.py
+++ b/charlib/characterizer/Characterizer.py
@@ -58,6 +58,7 @@ class CharacterizationSettings:
         self.results_dir = Path(kwargs.pop('results_dir', 'results'))
         self.debug = kwargs.pop('debug', False)
         self.debug_dir = Path(kwargs.pop('debug_dir', 'debug'))
+        self.quiet = kwargs.pop('quiet', False)
         self.cell_defaults = kwargs.get('cell_defaults', {})
 
         # Units and important voltages

--- a/charlib/characterizer/TestManager.py
+++ b/charlib/characterizer/TestManager.py
@@ -60,7 +60,7 @@ class TestManager:
                                 for reg_name, reg_func in registered_functions.items():
                                     if reg_func == function:
                                         # Copy test vectors
-                                        print(f'Recognized {self.cell.name} pin {pin_name} function as {reg_name}')
+                                        # print(f'Recognized {self.cell.name} pin {pin_name} function as {reg_name}')
                                         function.stored_test_vectors = reg_func.test_vectors
                                 self.cell[pin_name].function = function
                             else:
@@ -240,7 +240,8 @@ class TestManager:
 
         Assuming a black-box model, treat the cell as a grounded capacitor with fixed capacitance.
         Perform an AC sweep on the circuit and evaluate the capacitance as d/ds(i(s)/v(s))."""
-        print(f'Running input_capacitance for pin {target_pin} of cell {self.cell.name}')
+        if not settings.quiet:
+            print(f'Running input_capacitance for pin {target_pin} of cell {self.cell.name}')
         vdd = settings.vdd.voltage * settings.units.voltage
         vss = settings.vss.voltage * settings.units.voltage
         # TODO: Make these values configurable from settings
@@ -380,7 +381,8 @@ class CombinationalTestManager(TestManager):
         return self.cell
 
     def _run_delay(self, settings, harness: CombinationalHarness, slew, load, trial_name):
-        print(f'Running {trial_name} with slew={slew*settings.units.time}, load={load*settings.units.capacitance}')
+        if not settings.quiet:
+            print(f'Running {trial_name} with slew={slew*settings.units.time}, load={load*settings.units.capacitance}')
         harness.results[str(slew)][str(load)] = self._run_delay_trial(settings, harness, slew, load)
 
     def _run_delay_trial(self, settings, harness: CombinationalHarness, slew, load):
@@ -740,7 +742,8 @@ class SequentialTestManager(TestManager):
         debug_path = settings.debug_dir / self.cell.name / 'delay' / harness.debug_path / \
                      f'slew_{slew}' / f'load_{load}'
     
-        print(f'Running sequential {trial_name} with slew={str(t_slew)}, load={str(c_load)}')
+        if not settings.quiet:
+            print(f'Running sequential {trial_name} with slew={str(t_slew)}, load={str(c_load)}')
         t_stab = self._find_stabilizing_time(settings, harness, t_slew, c_load, debug_path)
         (t_setup, t_hold) = self._find_setup_hold_delay(settings, harness, t_slew, c_load, t_stab, debug_path)
 

--- a/charlib/characterizer/run.py
+++ b/charlib/characterizer/run.py
@@ -32,11 +32,13 @@ def main():
 
     # Set up charlib run arguments
     parser_characterize.add_argument('library', type=str,
-            help='The directory containing the library characterization configuration file')
+            help='The directory containing the library characterization configuration file, or the full path to the file')
+    parser_characterize.add_argument('-o', '--output', type=str, default='',
+            help='Place the characterization results in the specified file')
     parser_characterize.add_argument('--multithreaded', action='store_true',
             help='Enable multithreaded execution')
     parser_characterize.add_argument('--comparewith', type=str, default='',
-            help='A liberty file to compare results with.')
+            help='A liberty file to compare results with')
     parser_characterize.add_argument('-f', '--filters', nargs='*',
             help='A list of one or more regex strings. charlib will only characterize cells matching one or more of the filters.')
     parser_characterize.set_defaults(func=run_charlib)
@@ -154,9 +156,13 @@ def run_charlib(args):
     library = characterizer.characterize()
 
     # Export
-    results_dir = characterizer.settings.results_dir
-    results_dir.mkdir(parents=True, exist_ok=True)
-    libfile_name = results_dir / f'{library.name}.lib'
+    if args.output:
+        # Make directory if needed
+        libfile_name = Path(args.output)
+    else:
+        results_dir = characterizer.settings.results_dir
+        libfile_name = results_dir / f'{library.name}.lib'
+    libfile_name.parent.mkdir(parents=True, exist_ok=True)
     with open(libfile_name, 'w') as libfile:
         libfile.write(str(library))
         if not characterizer.settings.quiet:

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -47,6 +47,7 @@ These keys may optionally be included to adjust CharLib behavior:
 * `results_dir`: The directory to use for exporting characterization results. If omitted, CharLib creates a `results` directory in the current folder.
 * `debug`: A boolean which tells CharLib to display debug messages and store simulation SPICE files. Defaults to False.
 * `debug_dir`: The directory to use when storing simulation debug SPICE files. Defaults to `debug`.
+* `quiet`: A boolean which tells CharLib to minimize the number of messages and data displayed to the console. Defaults to False.
 
 ## Cells
 Specific cells to characterize are specified as entries under the `cells` key.


### PR DESCRIPTION
Fixes #37 and #38

- Add a `--quiet` flag to reduce output on the command line
- Add a feature to allow filtering cells using regex from the command line
- Add a feature to allow overriding .lib filename and results directory from the command line