### PR TITLE
Add .yaml config file recognition (Fixes issue #49)

### DIFF
--- a/charlib/characterizer/run.py
+++ b/charlib/characterizer/run.py
@@ -77,7 +77,7 @@ def run_charlib(args):
     if Path(library_dir).is_file():
         filelist=[library_dir]
     else:
-        filelist=Path(library_dir).rglob('*.yml')
+        filelist=list(Path(library_dir).rglob('*.yml')) + list(Path(library_dir).rglob('*.yaml'))
     for file in filelist:
         try:
             with open(file, 'r') as f:


### PR DESCRIPTION
This PR targets the config file recognition upon the start of CharLib and adds the ability to also recognize YAML files with the _.yaml_ ending instead of only _.yml._ See also https://github.com/stineje/CharLib/issues/49
