### PR TITLE
Fix exception handling issues on characterization error (see https://github.com/stineje/CharLib/issues/47 )

### DIFF
--- a/charlib/characterizer/Characterizer.py
+++ b/charlib/characterizer/Characterizer.py
@@ -39,7 +39,7 @@ class Characterizer:
             cells = [self.characterize_cell(cell) for cell in self.tests]
 
         # Add cells to the library
-        [self.library.add_cell(cell) for cell in cells]
+        [self.library.add_cell(cell) for cell in cells if cell]
 
         return self.library
 
@@ -48,7 +48,7 @@ class Characterizer:
         try:
             return cell.characterize(self.settings)
         except Exception as e:
-            if self.omit_on_failure:
+            if self.settings.omit_on_failure:
                 print(f"Error characterizing cell {cell.name}: {e}")
             else:
                 raise e

--- a/charlib/characterizer/TestManager.py
+++ b/charlib/characterizer/TestManager.py
@@ -34,6 +34,8 @@ class TestManager:
             - loads: output capacitave loads to test
             - simulation_timestep: the time increment to use during simulation"""
         # Initialize the cell under test
+        self.name = name
+        
         self._cell = Cell(name, kwargs.get('area', 0))
         for pin_name in in_ports:
             self.cell.add_pin(pin_name, 'input')

--- a/charlib/characterizer/run.py
+++ b/charlib/characterizer/run.py
@@ -77,7 +77,7 @@ def run_charlib(args):
     if Path(library_dir).is_file():
         filelist=[library_dir]
     else:
-        filelist=Path(library_dir).rglob('*.yml')
+        filelist=list(Path(library_dir).rglob('*.yml')) + list(Path(library_dir).rglob('*.yaml'))
     for file in filelist:
         try:
             with open(file, 'r') as f:


### PR DESCRIPTION
When an exception occurs during characterization, the omit on failure functionality does not work as intended and results in a faulty termination.

First, the if condition had to be fixed as discussed in https://github.com/stineje/CharLib/issues/47#issuecomment-2786656869.

The following error was due to the TestManager class not having a _name_ attribute, so the print statement to inform the user about the exception threw another exception.

Finally, if the characaterization fails, _cell_ is of type _None_ and can not be passed to the _add_cell()_ function. This is prevented by checking that cell is not of type _None_.

With these changes, the characterization process finishes correctly, even if there are errors during simulation.