### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Feature Request]"
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/problem-report.md
+++ b/.github/ISSUE_TEMPLATE/problem-report.md
@@ -1,0 +1,30 @@
+---
+name: Problem report
+about: Get help with errors or report a bug
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Problem Description**
+A clear and concise description of what the problem is.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**To Reproduce**
+Provide detailed steps to reproduce the behavior. Include your yaml configuration and spice files if relevant. 
+
+> You can use triple backticks \`\`\` above and below code to create a nicely formatted code block. Please use this feature if you include yaml or spice.
+
+**System Configuration**
+ - OS: [e.g. Windows 11, macOS Sequoia, RHEL 9, etc.]
+ - Python Version: [Paste the output of `python --version` here]
+ - CharLib Version: [Find CharLib in the output of `pip list` and paste its version here]
+ - PySpice Version: [Find PySpice in the output of `pip list` and paste its version here]
+ - Spice Simulator: [e.g. ngspice or Xyce]
+ - Spice Simulator Version: [Paste the output of `ngspice -v` or `Xyce -v` (depending on your simulator) here]
+
+**Additional context**
+Add any other context about the problem here.

--- a/README.md
+++ b/README.md
@@ -36,10 +36,13 @@ Running `charlib --help` will display lots of useful information.
 ## Contributing
 We're glad you're interested in contributing to CharLib! See [CONTRIBUTING.md](https://github.com/stineje/CharLib/blob/main/CONTRIBUTING.md) for details on how to get involved.
 
+## Troubleshooting
+If you're having problems using CharLib, please [open a new issue](https://github.com/stineje/CharLib/issues/new/choose)
+
 ## Citing
 If you use this work in your research, please cite as follows:
 
-```tex
+```bibtex
 @inproceedings{mellor_charlib_2024,
     title = {{CharLib}: {An} {Open} {Source} {Standard} {Cell} {Library} {Characterizer}},
     shorttitle = {{CharLib}},


### PR DESCRIPTION
Add a few pretty basic issue templates and direct users to create issues in the README.

I'm aware that GitHub has a new yml-based issue system that's a lot slicker, but it's still in beta so I used the old method.