### PR TITLE
Add `pg_pin`s to Liberty file output

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,4 +22,23 @@ jobs:
         run: |
           pytest
 
+  Characterize-GF180-inv:
+    runs-on: ubuntu-latest
 
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: "Install CharLib"
+        run: |
+          pip install -e .[docs]
+
+      - name: "Download gf180mcu_osu cell SPICE models"
+        run: |
+          ./test/pdks/gf180/fetch_spice.sh
+
+      - name: "Characterize (using test/pdks/gf180.yml)"
+        run: |
+          charlib run test/pdks/gf180 -f inv

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,6 +31,10 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: "Install ngspice"
+        run: |
+          sudo apt update && sudo apt install -y libngspice0-dev
+
       - name: "Install CharLib"
         run: |
           pip install -e .[docs]
@@ -42,3 +46,9 @@ jobs:
       - name: "Characterize (using test/pdks/gf180.yml)"
         run: |
           charlib run test/pdks/gf180 -f inv
+
+      - name: "Record characterization results"
+        uses: actions/upload-artifact@v4
+        with:
+          name: characterization-results
+          path: results/GF180.lib

--- a/charlib/characterizer/TestManager.py
+++ b/charlib/characterizer/TestManager.py
@@ -300,6 +300,13 @@ class TestManager:
 
         return capacitance
 
+    def add_pg_pins(self, vdd, vss, pwell, nwell):
+        """Annotate cell liberty file with pg_pins"""
+        self._cell.add_pg_pin(vdd.name, vdd.name, 'primary_power')
+        self._cell.add_pg_pin(vss.name, vss.name, 'primary_ground')
+        self._cell.add_pg_pin(pwell.name, pwell.name, 'pwell')
+        self._cell.add_pg_pin(nwell.name, nwell.name, 'nwell')
+
 
 class CombinationalTestManager(TestManager):
     """A combinational cell test manager"""
@@ -310,6 +317,10 @@ class CombinationalTestManager(TestManager):
         for pin in self.in_ports:
             input_capacitance = self._run_input_capacitance(settings, pin.name) @ u_F
             self.cell[pin.name].capacitance = input_capacitance.convert(settings.units.capacitance.prefixed_unit).value
+
+        # FIXME: pg_pins should not be added here, but this is the first place we have access to
+        # the CharacterizationSettings after Cell init
+        self.add_pg_pins(settings.vdd, settings.vss, settings.pwell, settings.nwell)
 
         # Run delay simulation for all test vectors of each function
         for out_port in self.out_ports:
@@ -657,6 +668,10 @@ class SequentialTestManager(TestManager):
 
         # Save test results to cell
         normalize_t_units = lambda value: (value @ u_s).convert(settings.units.time.prefixed_unit).value
+
+        # FIXME: pg_pins should not be added here, but this is the first place we have access to
+        # the CharacterizationSettings after Cell init
+        self.add_pg_pins(settings.vdd, settings.vss, settings.pwell, settings.nwell)
 
         for out_port in self.out_ports:
             unsorted_harnesses = []


### PR DESCRIPTION
Fixes #72. Adds pg_pin write to cell outputs. Also adds a characterization run (just a GF180 inverter) to the test workflow.

Long term, we probably need to refactor the whole `named_nodes` construct. Currently `pg_pin`s are really awkward to add to cells because they're stored in CharacterizationSettings. (There's actually quite a bit I'd like to rearchitect here, but that's a longer term task)