### PR TITLE
Fix subckt connection order

### DIFF
--- a/charlib/characterizer/cell.py
+++ b/charlib/characterizer/cell.py
@@ -163,6 +163,12 @@ class Cell:
         for pair in self.diff_pairs.values():
             yield from pair.as_pins()
 
+    def pins_in_netlist_order(self):
+        """Yield all pins in the order they appear in the netlist"""
+        pins = {p.name: p for p in self.all_pins()}
+        for pin_name in self.subckt().split()[2:]:
+            yield pins[pin_name]
+
     def filter_pins(self, **attrs):
         """Return a collection of pins matching the given directions, roles, etc.
 

--- a/charlib/characterizer/procedures/combinational/delay.py
+++ b/charlib/characterizer/procedures/combinational/delay.py
@@ -65,7 +65,7 @@ def measure_delays_for_path_with_criterion(cell, config, settings, variation, pa
         pin_map = utils.PinStateMap(cell.inputs, cell.outputs, state_map)
         connections = []
         measurements = []
-        for pin in cell.all_pins():
+        for pin in cell.pins_in_netlist_order():
             match pin.role:
                 case Port.Role.LOGIC: # Digital logic inputs or outputs
                     if pin.name in pin_map.target_inputs:

--- a/charlib/characterizer/procedures/pin_capacitance/ac_sweep.py
+++ b/charlib/characterizer/procedures/pin_capacitance/ac_sweep.py
@@ -45,7 +45,7 @@ def measure_pin_cap_by_ac_sweep(cell, settings, config, target_pin):
 
     # Initialize device under test and wire up pins
     connections = []
-    for pin in cell.all_pins():
+    for pin in cell.pins_in_netlist_order():
         match pin.role:
             case Port.Role.POWER:
                 connections.append(settings.primary_power.name)

--- a/charlib/characterizer/procedures/sequential/constraint/metastability/c2q_contour.py
+++ b/charlib/characterizer/procedures/sequential/constraint/metastability/c2q_contour.py
@@ -486,19 +486,19 @@ def get_c2q(cell, config, settings, t_clk_slew, t_data_slew, t_setup_skew, t_hol
 
     # Initialize device under test subcircuit and wire up pins
     connections = []
-    for pin in cell.all_pins():
-      if pin.role == 'clock':
-          connections.append('vclk')
-      elif pin.name == data_pin:
-          connections.append('vdata')
-      elif pin.name == output_pin:
-          connections.append('vout')
-      elif pin.role == 'primary_power':
-          connections.append('vdd')
-      elif pin.role == 'primary_ground':
-          connections.append('vss')
-      else:
-          connections.append('wfloat0')       # float unrecognized
+    for pin in cell.pins_in_netlist_order():
+        if pin.role == 'clock':
+            connections.append('vclk')
+        elif pin.name == data_pin:
+            connections.append('vdata')
+        elif pin.name == output_pin:
+            connections.append('vout')
+        elif pin.role == 'primary_power':
+            connections.append('vdd')
+        elif pin.role == 'primary_ground':
+            connections.append('vss')
+        else:
+            connections.append('wfloat0') # float unrecognized
     circuit.X('dut', cell.name, *connections)
 
     # Build the simulation


### PR DESCRIPTION
This commit fixes a bug during spice subcircuit wire-up which caused connections to be ordered incorrectly, resulting in signals feeding to the wrong subcircuit pins. Fixes #93.

This only happens when pins with special roles, such as power or biasing connections, are placed before I/O pins in the netlist. Our primary test PDK, OSU350, happens to have the I/O pins first (which is why we haven't encountered this so far).