### PR TITLE
Bugfixes: User paths, custom transient sim times, and incorrect logic thresholds in comb delay procedure

### DIFF
--- a/charlib/characterizer/cell.py
+++ b/charlib/characterizer/cell.py
@@ -46,8 +46,11 @@ class Cell:
 
         # Validate netlist
         netlist = cell_config['netlist']
-        if isinstance(netlist, (str, Path)):
-            if not Path(netlist).is_file():
+        if isinstance(netlist, str):
+            # Check for ~ and expand if present
+            netlist = Path(netlist).expanduser() if '~' in netlist else Path(netlist)
+        if isinstance(netlist, Path):
+            if not netlist.is_file():
                 raise ValueError(f'Invalid value for netlist: "{netlist}" is not a file')
             self.netlist = Path(netlist)
         else:
@@ -290,14 +293,15 @@ class CellTestConfig:
         for model in models:
             # Split to path and (optional) section, then validate both
             filename, *libname = model.split()
-            if not Path(filename).exists():
+            filename = Path(filename).expanduser() if '~' in filename else Path(filename)
+            if not filename.exists():
                 raise ValueError(f'Unable to locate model at "{filename}"')
             if len(libname) > 1:
                 raise ValueError(f'Expected 1 libname in model "{model}", got {len(libname)}:' \
                                  f'{libname}')
             elif not len(libname) == 1:
                 libname = []
-            self.models.append((Path(filename), *libname))
+            self.models.append((filename, *libname))
 
         self.timestep = timestep
         self.plots = plots

--- a/charlib/characterizer/procedures/combinational/delay.py
+++ b/charlib/characterizer/procedures/combinational/delay.py
@@ -8,17 +8,17 @@ from charlib.characterizer.procedures import register, ProcedureFailedException
 from charlib.liberty import liberty
 from charlib.liberty.library import LookupTable
 
-@register('data_slews', 'loads')
+@register('data_slews', 'loads', 'transient_sim_end_time')
 def combinational_worst_case(cell, config, settings):
     """Measure worst-case combinational transient and propagation delays"""
-    for variation in config.variations('data_slews', 'loads'):
+    for variation in config.variations('data_slews', 'loads', 'transient_sim_end_time'):
         for path in cell.paths():
             yield (measure_delays_for_path_with_criterion, cell, config, settings, variation, path, max)
 
-@register('data_slews', 'loads')
+@register('data_slews', 'loads', 'transient_sim_end_time')
 def combinational_average(cell, config, settings):
     """Measure combinational transient and propagation delays using a uniform average"""
-    for variation in config.variations('data_slews', 'loads'):
+    for variation in config.variations('data_slews', 'loads', 'transient_sim_end_time'):
         for path in cell.paths():
             yield (measure_delays_for_path_with_criterion, cell, config, settings, variation, path, average)
 
@@ -50,6 +50,7 @@ def measure_delays_for_path_with_criterion(cell, config, settings, variation, pa
     [input_pin, _, output_pin, _] = path
     data_slew = variation['data_slews'] * settings.units.time
     load = variation['loads'] * settings.units.capacitance
+    t_sim_end = max(variation['transient_sim_end_time'] * settings.units.time, 1000*data_slew)
     vdd = settings.primary_power.voltage * settings.units.voltage
     vss = settings.primary_ground.voltage * settings.units.voltage
 
@@ -140,7 +141,7 @@ def measure_delays_for_path_with_criterion(cell, config, settings, variation, pa
         simulation.options('autostop', 'nopage', 'nomod', post=1, ingold=2, trtol=1)
         for measure in measurements:
             simulation.measure(*measure, run=False)
-        simulation.transient(step_time=data_slew/8, end_time=1000*data_slew, run=False)
+        simulation.transient(step_time=data_slew/8, end_time=t_sim_end, run=False)
 
         stable_pins_map_str = ', '.join(['='.join([pin, state]) for pin, state in pin_map.stable_inputs.items()])
         try:

--- a/charlib/characterizer/procedures/combinational/delay.py
+++ b/charlib/characterizer/procedures/combinational/delay.py
@@ -76,8 +76,8 @@ def measure_delays_for_path_with_criterion(cell, config, settings, variation, pa
                             pin.name,
                             f'v{pin.name}', circuit.gnd,
                             values=utils.slew_pwl(v_0, v_1, data_slew, 3*data_slew,
-                                                  1e-2*settings.logic_thresholds.low,
-                                                  1e-2*settings.logic_thresholds.high))
+                                                  settings.logic_thresholds.low,
+                                                  settings.logic_thresholds.high))
                     elif pin.name in pin_map.target_outputs:
                         connections.append(f'v{pin.name}')
                         circuit.C(pin.name, f'v{pin.name}', circuit.gnd, load)
@@ -102,14 +102,14 @@ def measure_delays_for_path_with_criterion(cell, config, settings, variation, pa
                             measurement_names.add(prop_name)
                             measurements.append((
                                 'tran', prop_name,
-                                f'trig v(v{in_pin}) val={float(vdd*1e-2*threshold_prop_0)} {in_direction}=1',
-                                f'targ v(v{pin.name}) val={float(vdd*1e-2*threshold_prop_1)} {out_direction}=1'))
+                                f'trig v(v{in_pin}) val={float(vdd*threshold_prop_0)} {in_direction}=1',
+                                f'targ v(v{pin.name}) val={float(vdd*threshold_prop_1)} {out_direction}=1'))
                             tran_name = f'{out_direction}_transition__{in_pin}_to_{pin.name}'.lower()
                             measurement_names.add(tran_name)
                             measurements.append((
                                 'tran', tran_name,
-                                f'trig v(v{pin.name}) val={float(vdd*1e-2*threshold_tran_0)} {out_direction}=1',
-                                f'targ v(v{pin.name}) val={float(vdd*1e-2*threshold_tran_1)} {out_direction}=1'))
+                                f'trig v(v{pin.name}) val={float(vdd*threshold_tran_0)} {out_direction}=1',
+                                f'targ v(v{pin.name}) val={float(vdd*threshold_tran_1)} {out_direction}=1'))
                     elif pin.name in pin_map.stable_inputs:
                         if pin_map.stable_inputs[pin.name] == '0':
                             connections.append(settings.primary_ground.name)
@@ -169,8 +169,8 @@ def measure_delays_for_path_with_criterion(cell, config, settings, variation, pa
             fig = plots.plot_io_voltages(analyses.values(), list(pin_map.target_inputs.keys()),
                                          list(pin_map.target_outputs.keys()),
                                          legend_labels=analyses.keys(),
-                                         indicate_voltages=[settings.primary_power.voltage*1e-2*settings.logic_thresholds.low,
-                                                            settings.primary_power.voltage*1e-2*settings.logic_thresholds.high])
+                                         indicate_voltages=[settings.primary_power.voltage*settings.logic_thresholds.low,
+                                                            settings.primary_power.voltage*settings.logic_thresholds.high])
             # FIXME: let user decide whether to show or save
             fig_path = settings.plots_dir / cell.name / 'io'
             fig_path.mkdir(parents=True, exist_ok=True)

--- a/charlib/config/syntax.py
+++ b/charlib/config/syntax.py
@@ -143,6 +143,15 @@ class ConfigFile:
         ) : [Or(float, int)],
         Optional(
             Literal(
+                'transient_sim_end_time',
+                description='Optional extended end time for transient simulations, specified in ' \
+                            '``settings.units.time`` units. Default 0. This key is not usually ' \
+                            'required except when underdriving cells. When set to 0, the ' \
+                            'default end time of 1000*data_slew is used.'
+            ), default=0
+        ): Or(float, int),
+        Optional(
+            Literal(
                 'metastability_constraint_search_tolerance',
                 description='Tolerance used during setup/hold constraint search. Unit is ' \
                             'specified by ``settings.units.time``.'


### PR DESCRIPTION
This PR fixes a couple of issues:
- User paths (e.g. ~/path/to/my/pdk/or/spice) are now expanded correctly. This should be very handy for people using ciel for PDK version management, which places pdks in ~/.ciel by default.
- Adds the option to use custom transient simulation end times. This fixes #96 by allowing users to specify custom (longer) runtimes if desired. Since these procedures use the `autostop` option, this should not result in a longer total runtime except where actually required. Most users won't need this feature.
- Corrects the interpretation of logic thresholds in combinational delay measurement. These are ratios (0.0-1.0) rather than percentages (0-100) now. Fixes #98. 