### PR TITLE
Add static leakage power measurements for combinational cells

### DIFF
--- a/charlib/characterizer/characterizer.py
+++ b/charlib/characterizer/characterizer.py
@@ -71,6 +71,8 @@ class Characterizer:
         else:
             # Measure combinational propagation and transient delays
             simulations += self.settings.simulation.combinational_delay(cell, config, self.settings)
+            # Measure static leakage power for all input states
+            simulations += self.settings.simulation.combinational_leakage(cell, config, self.settings)
         return simulations
 
     def characterize(self):
@@ -189,6 +191,9 @@ class SimulationSettings:
         ]['callable']
         self.combinational_delay = registered_procedures[
             kwargs.get('combinational_delay_procedure', 'combinational_worst_case')
+        ]['callable']
+        self.combinational_leakage = registered_procedures[
+            kwargs.get('combinational_leakage_procedure', 'combinational_leakage')
         ]['callable']
         self.sequential_delay = registered_procedures[
             kwargs.get('sequential_delay_procedure', 'sequential_worst_case')

--- a/charlib/characterizer/characterizer.py
+++ b/charlib/characterizer/characterizer.py
@@ -14,6 +14,7 @@ from charlib.liberty.library import Library
 
 import charlib.characterizer.procedures.pin_capacitance.ac_sweep
 import charlib.characterizer.procedures.combinational.delay
+import charlib.characterizer.procedures.combinational.leakage_power
 import charlib.characterizer.procedures.sequential.delay
 import charlib.characterizer.procedures.sequential.constraint.metastability.binary_search
 import charlib.characterizer.procedures.sequential.constraint.metastability.c2q_contour

--- a/charlib/characterizer/procedures/combinational/leakage_power.py
+++ b/charlib/characterizer/procedures/combinational/leakage_power.py
@@ -1,0 +1,97 @@
+import itertools
+import PySpice
+
+from charlib.characterizer import utils
+from charlib.characterizer.cell import Port
+from charlib.characterizer.procedures import register, ProcedureFailedException
+from charlib.liberty import liberty
+
+
+@register
+def combinational_leakage(cell, config, settings):
+    """Measure static leakage power for all 2^N input state combinations"""
+    for state_bits in itertools.product('01', repeat=len(cell.inputs)):
+        state_map = dict(zip(cell.inputs, state_bits))
+        yield (measure_leakage_for_state, cell, config, settings, state_map)
+
+
+def build_when_str(state_map):
+    """Return a Liberty boolean expression for the given input state.
+    Extracted to a standalone method so it can be tested in test/logic/test_combinational_leakage.py
+
+    e.g. {'A': '0', 'B': '1'} -> '!A & B'
+    """
+    parts = [f'!{name}' if val == '0' else name for name, val in state_map.items()]
+    return ' & '.join(parts)
+
+
+def measure_leakage_for_state(cell, config, settings, state_map):
+    """Run one DC operating point and write one leakage_power group to cell.liberty.
+
+    :param cell: Cell object under test.
+    :param config: CellTestConfig with model paths and cell-specific config.
+    :param settings: CharacterizationSettings with library-wide config.
+    :param state_map: dict mapping each logic input name to '0' or '1'.
+    """
+    circuit = utils.init_circuit(
+        'leakage', cell.netlist, config.models, settings.named_nodes, settings.units
+    )
+
+    connections = []
+    for pin in cell.pins_in_netlist_order():
+        match pin.role:
+            case Port.Role.LOGIC:
+                connections.append(f'v{pin.name}')
+                if pin.name in cell.inputs:
+                    v = settings.primary_power.voltage if state_map[pin.name] == '1' else 0
+                    circuit.V(pin.name, f'v{pin.name}', circuit.gnd, v * settings.units.voltage)
+                # outputs: node named v{pin.name}, driven to DC rail by the cell, no load
+            case Port.Role.POWER:
+                connections.append(settings.primary_power.name)
+            case Port.Role.GROUND:
+                connections.append(settings.primary_ground.name)
+            case Port.Role.NWELL:
+                connections.append(settings.nwell.name)
+            case Port.Role.PWELL:
+                connections.append(settings.pwell.name)
+            case _:
+                raise ValueError(f'Unable to connect unrecognized pin {pin.name} in cell {cell.name}')
+    circuit.X('dut', cell.name, *connections)
+
+    simulator = PySpice.Simulator.factory(simulator=settings.simulation.backend)
+    simulation = simulator.simulation(
+        circuit,
+        temperature=settings.temperature,
+        nominal_temperature=settings.temperature
+    )
+    simulation.options('nopage', 'nomod')
+    simulation.operating_point()
+
+    try:
+        analysis = simulator.run(simulation)
+    except Exception as e:
+        msg = (f'Procedure measure_leakage_for_state failed for cell {cell.name} '
+               f'with state {state_map}')
+        if settings.debug:
+            debug_path = settings.debug_dir / cell.name / __name__.split('.')[-1]
+            debug_path.mkdir(parents=True, exist_ok=True)
+            with open(debug_path / f'state = {state_map}.sp', 'w', encoding='utf-8') as f:
+                f.write(str(simulation))
+        raise ProcedureFailedException(msg) from e
+
+    # Branch current: ngspice names it <element_name>#branch, simplified to <element_name> (lower)
+    i_vdd = float(analysis.branches[settings.primary_power.name.lower()])
+    power_W = settings.primary_power.voltage * abs(i_vdd)
+    power_value = (power_W @ PySpice.Unit.u_W).convert(
+        settings.units.leakage_power.prefixed_unit
+    ).value
+
+    when_str = build_when_str(state_map)
+
+    # Use when_str as identifier so multiple leakage_power groups in the same cell don't collide
+    result = cell.liberty
+    lp_group = liberty.Group('leakage_power', f'/* {when_str} */')
+    lp_group.add_attribute('when', when_str)
+    lp_group.add_attribute('value', power_value)
+    result.add_group(lp_group)
+    return result

--- a/charlib/characterizer/procedures/combinational/leakage_power.py
+++ b/charlib/characterizer/procedures/combinational/leakage_power.py
@@ -80,10 +80,10 @@ def measure_leakage_for_state(cell, config, settings, state_map):
         raise ProcedureFailedException(msg) from e
 
     # Branch current: ngspice names it <element_name>#branch, simplified to <element_name> (lower)
-    i_vdd = float(analysis.branches[settings.primary_power.name.lower()])
+    i_vdd = float(analysis.branches[settings.primary_power.name.lower()][0])
     power_W = settings.primary_power.voltage * abs(i_vdd)
     power_value = (power_W @ PySpice.Unit.u_W).convert(
-        settings.units.leakage_power.prefixed_unit
+        settings.units.power.prefixed_unit
     ).value
 
     when_str = build_when_str(state_map)

--- a/charlib/config/syntax.py
+++ b/charlib/config/syntax.py
@@ -235,6 +235,13 @@ class ConfigFile:
             ) : str,
             Optional(
                 Literal(
+                    'combinational_leakage_procedure',
+                    description='The name of a procedure used to measure static leakage power ' \
+                                'for each input state of a combinational cell.' # TODO: Refer to docs for procedures
+                ), default='combinational_leakage'
+            ) : str,
+            Optional(
+                Literal(
                     'sequential_delay_procedure',
                     description='The name of a procedure used to measure delays associated with ' \
                                 'a sequential cell.' # TODO: Refer to docs for procedures

--- a/test/logic/test_combinational_leakage.py
+++ b/test/logic/test_combinational_leakage.py
@@ -1,0 +1,131 @@
+from unittest.mock import MagicMock
+
+from charlib.characterizer.procedures.combinational.leakage_power import combinational_leakage, build_when_str
+from charlib.liberty import liberty
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_cell(input_names):
+    """Return a minimal mock Cell with the given logic input names."""
+    cell = MagicMock()
+    cell.inputs = input_names
+    return cell
+
+# ---------------------------------------------------------------------------
+# Generator tests
+# ---------------------------------------------------------------------------
+
+def test_generator_yields_two_jobs_for_one_input():
+    """Single-input cell produces exactly 2 leakage states."""
+    cell = _make_cell(['IN'])
+    jobs = list(combinational_leakage(cell, None, None))
+    assert len(jobs) == 2
+
+
+def test_generator_yields_four_jobs_for_two_inputs():
+    """Two-input cell produces exactly 4 leakage states (2^2)."""
+    cell = _make_cell(['A', 'B'])
+    jobs = list(combinational_leakage(cell, None, None))
+    assert len(jobs) == 4
+
+
+def test_generator_state_maps_cover_all_combinations():
+    """All 2^N input combinations appear exactly once in the yielded state_maps."""
+    cell = _make_cell(['A', 'B'])
+    jobs = list(combinational_leakage(cell, None, None))
+    state_maps = [job[4] for job in jobs]  # state_map is the 5th element of each tuple
+
+    expected = [
+        {'A': '0', 'B': '0'},
+        {'A': '0', 'B': '1'},
+        {'A': '1', 'B': '0'},
+        {'A': '1', 'B': '1'},
+    ]
+    for expected_state in expected:
+        assert expected_state in state_maps
+
+
+def test_generator_first_element_is_procedure_function():
+    """Each yielded tuple begins with the measure_leakage_for_state callable."""
+    from charlib.characterizer.procedures.combinational.leakage_power import measure_leakage_for_state
+    cell = _make_cell(['IN'])
+    jobs = list(combinational_leakage(cell, None, None))
+    for job in jobs:
+        assert job[0] is measure_leakage_for_state
+
+
+# ---------------------------------------------------------------------------
+# when-string tests
+# ---------------------------------------------------------------------------
+
+def test_build_when_str_single_input_low():
+    """Input held low produces '!IN'."""
+    assert build_when_str({'IN': '0'}) == '!IN'
+
+
+def test_build_when_str_single_input_high():
+    """Input held high produces 'IN'."""
+    assert build_when_str({'IN': '1'}) == 'IN'
+
+
+def test_build_when_str_two_inputs_both_low():
+    assert build_when_str({'A': '0', 'B': '0'}) == '!A & !B'
+
+
+def test_build_when_str_two_inputs_mixed():
+    assert build_when_str({'A': '0', 'B': '1'}) == '!A & B'
+
+
+def test_build_when_str_two_inputs_both_high():
+    assert build_when_str({'A': '1', 'B': '1'}) == 'A & B'
+
+
+# ---------------------------------------------------------------------------
+# Liberty output structure tests
+# ---------------------------------------------------------------------------
+
+def test_liberty_group_has_correct_type():
+    """leakage_power group has the right Liberty group name."""
+    when = '!IN'
+    lp_group = liberty.Group('leakage_power', f'/* {when} */')
+    lp_group.add_attribute('when', when)
+    lp_group.add_attribute('value', 12.5)
+    assert lp_group.name == 'leakage_power'
+
+
+def test_liberty_group_when_attribute_is_quoted_in_output():
+    """Liberty serialization wraps the when condition in double quotes."""
+    when = '!A & B'
+    lp_group = liberty.Group('leakage_power', f'/* {when} */')
+    lp_group.add_attribute('when', when)
+    lp_group.add_attribute('value', 5.0)
+    output = lp_group.to_liberty()
+    assert f'"{when}"' in output
+
+
+def test_liberty_group_value_appears_in_output():
+    """Liberty serialization includes the numeric power value."""
+    lp_group = liberty.Group('leakage_power', '/* !IN */')
+    lp_group.add_attribute('when', '!IN')
+    lp_group.add_attribute('value', 7.3)
+    output = lp_group.to_liberty()
+    assert '7.3' in output
+
+
+def test_two_leakage_groups_coexist_in_cell_liberty():
+    """Adding two leakage_power groups with different when conditions does not overwrite either."""
+    cell_group = liberty.Group('cell', 'inv')
+
+    for when, val in [('!IN', 10.0), ('IN', 5.0)]:
+        lp = liberty.Group('leakage_power', f'/* {when} */')
+        lp.add_attribute('when', when)
+        lp.add_attribute('value', val)
+        cell_group.add_group(lp)
+
+    output = cell_group.to_liberty()
+    assert output.count('leakage_power (') == 2
+    assert '"!IN"' in output
+    assert 'when : IN' in output


### PR DESCRIPTION
This PR implements `charlib/characterizer/procedures/combinational/leakage_power.py` which sets up DC operating point simulations for all 2^N input configurations for a cell with N inputs. The leakage power is calculated as VDD * |I(VDD)| and written to the Liberty output as `leakage_power` groups with `when` and `value` attributes. 

The procedure is wired into `CharacterizationSettings` and `analyse_cell` in `characterizer.py`. The `combinational_leakage_procedure` YAML key is documented in `syntax.py`. Unit tests are in `test/logic/test_combinational_leakage.py`

It has been tested on a single (for now) combinational cell (FreePDK45 tx driver) to confirm the liberty output is correct. Sequential cell support is left for follow-up work. 

Minor note: the Liberty file output puts quotes around low inputs but not around high inputs (`"!IN"` vs `IN`) due to how the liberty module's `_to_safe_str()` method operates. I believe it is only a style/consistency issue and would be a simple one-line fix.