### PR TITLE
Include `ff`/`latch` groups in liberty output for sequential cells

### DIFF
--- a/charlib/characterizer/cell.py
+++ b/charlib/characterizer/cell.py
@@ -139,6 +139,8 @@ class Cell:
         ## 4. Add as much liberty data as we can right now
         self.liberty = liberty.Group('cell', name)
         self.liberty.add_attribute('area', cell_config.get('area', 0.0), 2)
+        def _to_lib_expr(pin):
+            return pin.name + "'" if p.is_inverted() else ""
         for pin, var in feedback_paths.items(): # Add storage groups
             # Get variable names
             if pin in [pair.inverting_port_name for pair in self.diff_pairs.values()]:
@@ -151,20 +153,19 @@ class Cell:
                 # No inverting output. Append inv to the end of the first var name
                 storage_vars.append(f'{var}inv')
             var_string = ', '.join(storage_vars)
-            to_expr = lambda p: f'{p.name}{"\'" if p.is_inverted() else ""}'
             if self.clock: # ff group
                 storage_group = liberty.Group('ff', var_string)
                 storage_group.add_attribute('next_state', self.functions[pin].expression)
-                storage_group.add_attribute('clocked_on', to_expr(self.clock))
+                storage_group.add_attribute('clocked_on', to_lib_expr(self.clock))
             else: # latch group
                 storage_group = liberty.Group('latch', var_string)
                 storage_group.add_attribute('data_in', self.functions[pin].expression)
                 if self.enable:
-                    storage_group.add_attribute('enable', to_expr(self.enable))
+                    storage_group.add_attribute('enable', to_lib_expr(self.enable))
             if self.clear:
-                storage_group.add_attribute('clear', to_expr(self.clear))
+                storage_group.add_attribute('clear', to_lib_expr(self.clear))
             if self.preset:
-                storage_group.add_attribute('preset', to_expr(self.preset))
+                storage_group.add_attribute('preset', to_lib_expr(self.preset))
             self.liberty.add_group(storage_group)
         for pin in self.all_pins(): # Add pin groups
             if pin.name in self.pg_pins:
@@ -179,8 +180,6 @@ class Cell:
                 elif pin.role == Port.Role.CLOCK:
                     pin_group.add_attribute('clock', "true")
             self.liberty.add_group(pin_group)
-        print(self.liberty.to_liberty())
-
 
     def subckt(self) -> str:
         """Return the subckt line matching this cell"""

--- a/charlib/characterizer/cell.py
+++ b/charlib/characterizer/cell.py
@@ -139,7 +139,7 @@ class Cell:
         ## 4. Add as much liberty data as we can right now
         self.liberty = liberty.Group('cell', name)
         self.liberty.add_attribute('area', cell_config.get('area', 0.0), 2)
-        def _to_lib_expr(pin):
+        def to_lib_expr(pin):
             return pin.name + "'" if pin.is_inverted() else ""
         for pin, var in feedback_paths.items(): # Add storage groups
             # Get variable names

--- a/charlib/characterizer/cell.py
+++ b/charlib/characterizer/cell.py
@@ -140,7 +140,7 @@ class Cell:
         self.liberty = liberty.Group('cell', name)
         self.liberty.add_attribute('area', cell_config.get('area', 0.0), 2)
         def to_lib_expr(pin):
-            return pin.name + "'" if pin.is_inverted() else ""
+            return pin.name + "'" if pin.is_inverted() else pin.name
         for pin, var in feedback_paths.items(): # Add storage groups
             # Get variable names
             if pin in [pair.inverting_port_name for pair in self.diff_pairs.values()]:

--- a/charlib/characterizer/cell.py
+++ b/charlib/characterizer/cell.py
@@ -127,10 +127,10 @@ class Cell:
                 raise ValueError(f'Expected outputs {cell_config["outputs"]}, found {self.outputs}')
 
         ## 3. Construct functions based on pin types & feedback paths
-        state_map = {v: k for k, v in [_parse_expression(s) for s in cell_config.get('state', [])]}
+        feedback_paths = {v: k for k, v in [_parse_expression(s) for s in cell_config.get('state', [])]}
         for output, expression in functions.items():
             is_inverting = output in [pair.inverting_port_name for pair in self.diff_pairs.values()]
-            state = state_map.get(output, None)
+            state = feedback_paths.get(output, None)
             # TODO: Pass only pins which are related to this function
             # TODO: Handle multiple clocks, etc.
             [output_pin] = list(self.filter_pins(name=output))
@@ -139,7 +139,34 @@ class Cell:
         ## 4. Add as much liberty data as we can right now
         self.liberty = liberty.Group('cell', name)
         self.liberty.add_attribute('area', cell_config.get('area', 0.0), 2)
-        for pin in self.all_pins():
+        for pin, var in feedback_paths.items(): # Add storage groups
+            # Get variable names
+            if pin in [pair.inverting_port_name for pair in self.diff_pairs.values()]:
+                continue # skip inverting pins
+            storage_vars = [var,]
+            for pair in self.diff_pairs.values():
+                if pin == pair.noninverting_port_name:
+                    storage_vars.append(feedback_paths[pair.complement(pin)])
+            if len(storage_vars) < 2:
+                # No inverting output. Append inv to the end of the first var name
+                storage_vars.append(f'{var}inv')
+            var_string = ', '.join(storage_vars)
+            to_expr = lambda p: f'{p.name}{"\'" if p.is_inverted() else ""}'
+            if self.clock: # ff group
+                storage_group = liberty.Group('ff', var_string)
+                storage_group.add_attribute('next_state', self.functions[pin].expression)
+                storage_group.add_attribute('clocked_on', to_expr(self.clock))
+            else: # latch group
+                storage_group = liberty.Group('latch', var_string)
+                storage_group.add_attribute('data_in', self.functions[pin].expression)
+                if self.enable:
+                    storage_group.add_attribute('enable', to_expr(self.enable))
+            if self.clear:
+                storage_group.add_attribute('clear', to_expr(self.clear))
+            if self.preset:
+                storage_group.add_attribute('preset', to_expr(self.preset))
+            self.liberty.add_group(storage_group)
+        for pin in self.all_pins(): # Add pin groups
             if pin.name in self.pg_pins:
                 pin_group = liberty.Group('pg_pin', pin.name)
                 pin_group.add_attribute('voltage_name', pin.name)
@@ -152,6 +179,7 @@ class Cell:
                 elif pin.role == Port.Role.CLOCK:
                     pin_group.add_attribute('clock', "true")
             self.liberty.add_group(pin_group)
+        print(self.liberty.to_liberty())
 
 
     def subckt(self) -> str:

--- a/charlib/characterizer/cell.py
+++ b/charlib/characterizer/cell.py
@@ -148,7 +148,11 @@ class Cell:
             storage_vars = [var,]
             for pair in self.diff_pairs.values():
                 if pin == pair.noninverting_port_name:
-                    storage_vars.append(feedback_paths[pair.complement(pin)])
+                    try:
+                        complement_var = feedback_paths[pair.complement(pin)]
+                    except KeyError as e:
+                        raise ValueError(f'No state feedback path for differential pair member {pair.complement(pin)}') from e
+                    storage_vars.append(complement_var)
             if len(storage_vars) < 2:
                 # No inverting output. Append inv to the end of the first var name
                 storage_vars.append(f'{var}inv')

--- a/charlib/characterizer/cell.py
+++ b/charlib/characterizer/cell.py
@@ -140,7 +140,7 @@ class Cell:
         self.liberty = liberty.Group('cell', name)
         self.liberty.add_attribute('area', cell_config.get('area', 0.0), 2)
         def _to_lib_expr(pin):
-            return pin.name + "'" if p.is_inverted() else ""
+            return pin.name + "'" if pin.is_inverted() else ""
         for pin, var in feedback_paths.items(): # Add storage groups
             # Get variable names
             if pin in [pair.inverting_port_name for pair in self.diff_pairs.values()]:

--- a/charlib/characterizer/port.py
+++ b/charlib/characterizer/port.py
@@ -114,13 +114,13 @@ class DifferentialPair(Port):
             return item in list(self.as_pins())
         return False
 
-    def complement(self, port_name):
+    def complement(self, port_name: str) -> str:
         """Given the name of one port in the pair, return the other port.
 
         Returns None if port_name is not in the DifferentialPair."""
         if port_name == self.noninverting_port_name:
             return self.inverting_port_name
-        elif port_name == self.inverting_port_name:
+        if port_name == self.inverting_port_name:
             return self.noninverting_port_name
         return None
 

--- a/charlib/characterizer/port.py
+++ b/charlib/characterizer/port.py
@@ -106,7 +106,7 @@ class DifferentialPair(Port):
         self.noninverting_port_name = noninverting_port_name
         self.inverting_port_name = inverting_port_name
 
-    def __contains__(self, item):
+    def __contains__(self, item) -> bool:
         """Implements 'in' operator"""
         if isinstance(item, str):
             return item in [self.noninverting_port_name, self.inverting_port_name]
@@ -114,7 +114,7 @@ class DifferentialPair(Port):
             return item in list(self.as_pins())
         return False
 
-    def complement(self, port_name: str) -> str:
+    def complement(self, port_name: str) -> str|None:
         """Given the name of one port in the pair, return the other port.
 
         Returns None if port_name is not in the DifferentialPair."""

--- a/charlib/characterizer/port.py
+++ b/charlib/characterizer/port.py
@@ -70,6 +70,13 @@ class Port:
     def __repr__(self) -> str:
         return f'Port({self.name}, {self.direction}, {self.role}, {self.trigger})'
 
+    def __eq__(self, other: Port) -> bool:
+        """Implements == operator"""
+        return self.name == other.name \
+            and self.direction == other.direction \
+            and self.role == other.role \
+            and self.trigger == other.trigger
+
     def is_edge_triggered(self) -> bool:
         """Return whether this port is edge-triggered."""
         return bool(self.trigger)
@@ -82,6 +89,10 @@ class Pin(Port):
         """Construct a new pin."""
         super().__init__(name, direction, role, edge_triggered)
         self.inversion = inverted
+
+    def __eq__(self, other: Pin) -> bool:
+        """Implements == operator"""
+        return super().__eq__(other) and self.inversion == other.inversion
 
     def is_inverted(self) -> bool:
         """Return whether this port is inverted.

--- a/charlib/characterizer/port.py
+++ b/charlib/characterizer/port.py
@@ -70,8 +70,10 @@ class Port:
     def __repr__(self) -> str:
         return f'Port({self.name}, {self.direction}, {self.role}, {self.trigger})'
 
-    def __eq__(self, other: Port) -> bool:
+    def __eq__(self, other) -> bool:
         """Implements == operator"""
+        if type(other) is not type(self):
+            return NotImplemented
         return self.name == other.name \
             and self.direction == other.direction \
             and self.role == other.role \
@@ -90,8 +92,10 @@ class Pin(Port):
         super().__init__(name, direction, role, edge_triggered)
         self.inversion = inverted
 
-    def __eq__(self, other: Pin) -> bool:
+    def __eq__(self, other) -> bool:
         """Implements == operator"""
+        if type(other) is not type(self):
+            return NotImplemented
         return super().__eq__(other) and self.inversion == other.inversion
 
     def is_inverted(self) -> bool:

--- a/charlib/characterizer/port.py
+++ b/charlib/characterizer/port.py
@@ -106,7 +106,26 @@ class DifferentialPair(Port):
         self.noninverting_port_name = noninverting_port_name
         self.inverting_port_name = inverting_port_name
 
+    def __contains__(self, item):
+        """Implements 'in' operator"""
+        if isinstance(item, str):
+            return item in [self.noninverting_port_name, self.inverting_port_name]
+        elif isinstance(item, Pin):
+            return item in list(self.as_pins())
+        return False
+
+    def complement(self, port_name):
+        """Given the name of one port in the pair, return the other port.
+
+        Returns None if port_name is not in the DifferentialPair."""
+        if port_name == self.noninverting_port_name:
+            return self.inverting_port_name
+        elif port_name == self.inverting_port_name:
+            return self.noninverting_port_name
+        return None
+
     def as_pins(self):
+        """Yield each member of the diff pair as Pin objects"""
         yield Pin(self.noninverting_port_name, self.direction, self.role, inverted=False,
                   edge_triggered=self.trigger)
         yield Pin(self.inverting_port_name, self.direction, self.role, inverted=True,


### PR DESCRIPTION
Fixes #64. Adds `ff` and `latch` groups to liberty files based on the presence of the `state` key in the cell YAML. Also adds a few new helper methods to Port subclasses.