### PR TITLE
Add Q/V method prodecure option for input pin capacitance

### DIFF
--- a/charlib/characterizer/cell.py
+++ b/charlib/characterizer/cell.py
@@ -292,7 +292,7 @@ class Cell:
                                   '10'.
         """
         for tv in self.functions[output_pin].test_vectors:
-            if tv[input_pin] == input_transition and tv[output_pin] == output_transition:
+            if tv.get(input_pin) == input_transition and tv[output_pin] == output_transition:
                 yield tv
 
     @property

--- a/charlib/characterizer/characterizer.py
+++ b/charlib/characterizer/characterizer.py
@@ -13,7 +13,7 @@ from charlib.characterizer.procedures import registered_procedures, ProcedureFai
 from charlib.liberty.library import Library
 
 import charlib.characterizer.procedures.pin_capacitance.ac_sweep
-import charlib.characterizer.procedures.pin_capacitance.qv_method
+import charlib.characterizer.procedures.pin_capacitance.charge_integration
 import charlib.characterizer.procedures.combinational.delay
 import charlib.characterizer.procedures.combinational.leakage_power
 import charlib.characterizer.procedures.sequential.delay

--- a/charlib/characterizer/characterizer.py
+++ b/charlib/characterizer/characterizer.py
@@ -13,6 +13,7 @@ from charlib.characterizer.procedures import registered_procedures, ProcedureFai
 from charlib.liberty.library import Library
 
 import charlib.characterizer.procedures.pin_capacitance.ac_sweep
+import charlib.characterizer.procedures.pin_capacitance.qv_method
 import charlib.characterizer.procedures.combinational.delay
 import charlib.characterizer.procedures.combinational.leakage_power
 import charlib.characterizer.procedures.sequential.delay

--- a/charlib/characterizer/procedures/pin_capacitance/charge_integration.py
+++ b/charlib/characterizer/procedures/pin_capacitance/charge_integration.py
@@ -9,14 +9,14 @@ from charlib.characterizer.procedures import register, ProcedureFailedException
 
 
 @register
-def qv_method(cell, config, settings):
-    """Measure input capacitance for each input pin using Q/V integration and return a liberty cell group"""
+def charge_integration(cell, config, settings):
+    """Measure input capacitance for each input pin using charge integration and return a liberty cell group"""
     roles = ['logic', 'clock', 'set', 'reset', 'enable']
     for target_pin in cell.filter_pins(direction=['input'], role=roles):
-        yield (measure_pin_cap_by_qv_method, cell, settings, config, target_pin.name)
+        yield (measure_pin_cap_by_charge_integration, cell, settings, config, target_pin.name)
 
 
-def measure_pin_cap_by_qv_method(cell, settings, config, target_pin):
+def measure_pin_cap_by_charge_integration(cell, settings, config, target_pin):
     """Use a PWL stimulus to ramp the input through a full VDD swing and integrate i(vstim).
 
     Applies a VSS→VDD→VSS waveform to the target pin. The charge drawn on the rising
@@ -114,7 +114,7 @@ def measure_pin_cap_by_qv_method(cell, settings, config, target_pin):
     try:
         analysis = simulator.run(simulation)
     except Exception as e:
-        msg = (f'Procedure measure_pin_cap_by_qv_method failed for cell {cell.name}, '
+        msg = (f'Procedure measure_pin_cap_by_charge_integration failed for cell {cell.name}, '
                f'pin {target_pin}')
         raise ProcedureFailedException(msg) from e
 

--- a/charlib/characterizer/procedures/pin_capacitance/charge_integration.py
+++ b/charlib/characterizer/procedures/pin_capacitance/charge_integration.py
@@ -123,10 +123,18 @@ def measure_pin_cap_by_charge_integration(cell, settings, config, target_pin):
     if math.isnan(q_rise) or math.isnan(q_fall):
         return result
 
-    # C = |Q| / VDD, averaged over both edges
-    capacitance_F = (abs(q_rise) + abs(q_fall)) / 2 / settings.primary_power.voltage
+    # C = |Q| / VDD per edge; capacitance is the average
+    vdd_v = settings.primary_power.voltage
+    rise_cap_F = abs(q_rise) / vdd_v
+    fall_cap_F = abs(q_fall) / vdd_v
+    avg_cap_F  = (rise_cap_F + fall_cap_F) / 2
 
-    converted_cap = (capacitance_F @ u_F).convert(settings.units.capacitance.prefixed_unit).value
-    result.group('pin', target_pin).add_attribute('capacitance', converted_cap)
+    def to_lib(cap_F):
+        return (cap_F @ u_F).convert(settings.units.capacitance.prefixed_unit).value
+
+    pin_group = result.group('pin', target_pin)
+    pin_group.add_attribute('rise_capacitance', to_lib(rise_cap_F))
+    pin_group.add_attribute('fall_capacitance', to_lib(fall_cap_F))
+    pin_group.add_attribute('capacitance',      to_lib(avg_cap_F))
 
     return result

--- a/charlib/characterizer/procedures/pin_capacitance/charge_integration.py
+++ b/charlib/characterizer/procedures/pin_capacitance/charge_integration.py
@@ -8,7 +8,7 @@ from charlib.characterizer.cell import Port
 from charlib.characterizer.procedures import register, ProcedureFailedException
 
 
-@register
+@register('data_slews', 'charge_integration_t_slew', 'charge_integration_t_wait')
 def charge_integration(cell, config, settings):
     """Measure input capacitance for each input pin using charge integration and return a liberty cell group"""
     roles = ['logic', 'clock', 'set', 'reset', 'enable']
@@ -31,9 +31,14 @@ def measure_pin_cap_by_charge_integration(cell, settings, config, target_pin):
     vdd = settings.primary_power.voltage * settings.units.voltage
     vss = settings.primary_ground.voltage * settings.units.voltage
 
-    # TODO: Make these values configurable
-    t_slew = 0.5 @ u_ns    # ramp duration VSS→VDD (or VDD→VSS)
-    t_wait = 5 * t_slew    # settling time before and between edges
+    t_slew_val = config.parameters.get('charge_integration_t_slew', 0)
+    if t_slew_val == 0:
+        t_slew_val = min(config.parameters.get('data_slews', [0.5]))  # default: fastest data slew
+    t_wait_val = config.parameters.get('charge_integration_t_wait', 0)
+    if t_wait_val == 0:
+        t_wait_val = 1000 * t_slew_val # default: 1000x t_slew
+    t_slew = t_slew_val * settings.units.time
+    t_wait = t_wait_val * settings.units.time
     r_out  = 10 @ u_GOhm
     c_out  = 1  @ u_pF
 
@@ -123,11 +128,11 @@ def measure_pin_cap_by_charge_integration(cell, settings, config, target_pin):
     if math.isnan(q_rise) or math.isnan(q_fall):
         return result
 
-    # C = |Q| / VDD per edge; capacitance is the average
+    # C = |Q| / VDD per edge; capacitance is the worst-case
     vdd_v = settings.primary_power.voltage
     rise_cap_F = abs(q_rise) / vdd_v
     fall_cap_F = abs(q_fall) / vdd_v
-    avg_cap_F  = (rise_cap_F + fall_cap_F) / 2
+    worst_cap_F  = max(rise_cap_F, fall_cap_F)
 
     def to_lib(cap_F):
         return (cap_F @ u_F).convert(settings.units.capacitance.prefixed_unit).value
@@ -135,6 +140,6 @@ def measure_pin_cap_by_charge_integration(cell, settings, config, target_pin):
     pin_group = result.group('pin', target_pin)
     pin_group.add_attribute('rise_capacitance', to_lib(rise_cap_F))
     pin_group.add_attribute('fall_capacitance', to_lib(fall_cap_F))
-    pin_group.add_attribute('capacitance',      to_lib(avg_cap_F))
+    pin_group.add_attribute('capacitance',      to_lib(worst_cap_F))
 
     return result

--- a/charlib/characterizer/procedures/pin_capacitance/qv_method.py
+++ b/charlib/characterizer/procedures/pin_capacitance/qv_method.py
@@ -1,0 +1,132 @@
+import math
+
+import PySpice
+from PySpice.Unit import *
+
+from charlib.characterizer import utils
+from charlib.characterizer.cell import Port
+from charlib.characterizer.procedures import register, ProcedureFailedException
+
+
+@register
+def qv_method(cell, config, settings):
+    """Measure input capacitance for each input pin using Q/V integration and return a liberty cell group"""
+    roles = ['logic', 'clock', 'set', 'reset', 'enable']
+    for target_pin in cell.filter_pins(direction=['input'], role=roles):
+        yield (measure_pin_cap_by_qv_method, cell, settings, config, target_pin.name)
+
+
+def measure_pin_cap_by_qv_method(cell, settings, config, target_pin):
+    """Use a PWL stimulus to ramp the input through a full VDD swing and integrate i(vstim).
+
+    Applies a VSS→VDD→VSS waveform to the target pin. The charge drawn on the rising
+    and falling edges is integrated separately; C_in = (|Q_rise| + |Q_fall|) / 2 / VDD.
+    All other pins are isolated with a large R and small C to ground, matching the AC
+    sweep topology.
+
+    Returns a liberty cell group with the capacitance set on the appropriate pin.
+    """
+    result = cell.liberty
+
+    vdd = settings.primary_power.voltage * settings.units.voltage
+    vss = settings.primary_ground.voltage * settings.units.voltage
+
+    # TODO: Make these values configurable
+    t_slew = 0.5 @ u_ns    # ramp duration VSS→VDD (or VDD→VSS)
+    t_wait = 5 * t_slew    # settling time before and between edges
+    r_out  = 10 @ u_GOhm
+    c_out  = 1  @ u_pF
+
+    # Convert to SI seconds for the .meas from=/to= strings
+    t_slew_s = float(t_slew.value) * float(t_slew.scale)
+    t_wait_s = float(t_wait.value) * float(t_wait.scale)
+
+    t_rise_start = t_wait_s
+    t_rise_end   = t_wait_s + t_slew_s
+    t_fall_start = 2 * t_wait_s + t_slew_s
+    t_fall_end   = 2 * t_wait_s + 2 * t_slew_s
+    t_sim_end    = 3 * t_wait + 2 * t_slew
+
+    # Initialize circuit
+    circuit_name = f'cell-{cell.name}-pin-{target_pin}-cap'
+    circuit = utils.init_circuit(circuit_name, cell.netlist, config.models,
+                                 settings.named_nodes, settings.units)
+
+    # PWL stimulus: flat at VSS, ramp to VDD, flat at VDD, ramp back to VSS
+    circuit.PieceWiseLinearVoltageSource('stim', 'vin', circuit.gnd, values=[
+        (0 @ u_ns,                              vss),
+        (t_wait,                                vss),
+        (t_wait + t_slew,                       vdd),
+        (t_wait + t_slew + t_wait,              vdd),
+        (t_wait + t_slew + t_wait + t_slew,     vss),
+    ])
+
+    # Wire up device under test
+    connections = []
+    for pin in cell.pins_in_netlist_order():
+        match pin.role:
+            case Port.Role.POWER:
+                connections.append(settings.primary_power.name)
+            case Port.Role.GROUND:
+                connections.append(settings.primary_ground.name)
+            case Port.Role.NWELL:
+                connections.append(settings.nwell.name)
+            case Port.Role.PWELL:
+                connections.append(settings.pwell.name)
+            case _:
+                if pin.name == target_pin:
+                    connections.append('vin')
+                else:
+                    # TODO: Determine whether the capacitors are actually needed.
+                    circuit.C(pin.name, f'v{pin.name}', circuit.gnd, c_out)
+                    circuit.R(pin.name, f'v{pin.name}', circuit.gnd, r_out)
+                    connections.append(f'v{pin.name}')
+    circuit.X('dut', cell.name, *connections)
+
+    # Set up simulation
+    simulator = PySpice.Simulator.factory(simulator=settings.simulation.backend)
+    simulation = simulator.simulation(
+        circuit,
+        temperature=settings.temperature,
+        nominal_temperature=settings.temperature
+    )
+    simulation.options('nopage', 'nomod', post=1, ingold=2)
+
+    # Integrate i(vstim) over each edge; i(vstim) is negative when sourcing current
+    simulation.measure('tran', 'q_rise',
+                       'integ i(vstim)',
+                       f'from={t_rise_start:.6g}',
+                       f'to={t_rise_end:.6g}',
+                       run=False)
+    simulation.measure('tran', 'q_fall',
+                       'integ i(vstim)',
+                       f'from={t_fall_start:.6g}',
+                       f'to={t_fall_end:.6g}',
+                       run=False)
+    simulation.transient(step_time=t_slew / 10, end_time=t_sim_end, run=False)
+
+    if settings.debug:
+        debug_path = settings.debug_dir / cell.name / __name__.split('.')[-1]
+        debug_path.mkdir(parents=True, exist_ok=True)
+        with open(debug_path / f'{target_pin}.spice', 'w', encoding='utf-8') as spice_file:
+            spice_file.write(str(simulation))
+
+    try:
+        analysis = simulator.run(simulation)
+    except Exception as e:
+        msg = (f'Procedure measure_pin_cap_by_qv_method failed for cell {cell.name}, '
+               f'pin {target_pin}')
+        raise ProcedureFailedException(msg) from e
+
+    q_rise = analysis.measurements.get('q_rise', float('nan'))
+    q_fall = analysis.measurements.get('q_fall', float('nan'))
+    if math.isnan(q_rise) or math.isnan(q_fall):
+        return result
+
+    # C = |Q| / VDD, averaged over both edges
+    capacitance_F = (abs(q_rise) + abs(q_fall)) / 2 / settings.primary_power.voltage
+
+    converted_cap = (capacitance_F @ u_F).convert(settings.units.capacitance.prefixed_unit).value
+    result.group('pin', target_pin).add_attribute('capacitance', converted_cap)
+
+    return result

--- a/charlib/characterizer/utils.py
+++ b/charlib/characterizer/utils.py
@@ -30,7 +30,7 @@ class PinStateMap:
         # TODO: Make this more sophisticated, with list of Port objects as input instead of input
         # and output port names
         for name in inputs:
-            state = pin_states[name]
+            state = pin_states.get(name, '0')  # default unrelated inputs to stable-low
             if len(state) == 2:
                 self.target_inputs[name] = state
             elif len(state) == 1:

--- a/charlib/config/syntax.py
+++ b/charlib/config/syntax.py
@@ -152,6 +152,28 @@ class ConfigFile:
         ): Or(float, int),
         Optional(
             Literal(
+                'charge_integration_t_slew',
+                description='Ramp duration (VSS->VDD or VDD->VSS) used by the ' \
+                            'charge_integration input-capacitance procedure. Shorter ramps ' \
+                            'reduce gate-leakage charge accumulated during integration; ' \
+                            'values in the range 0.01-0.5 work well for sub-100 nm nodes. ' \
+                            'Unit is specified by ``settings.units.time``. Default 0 means ' \
+                            'automatically set to min(data_slews).'
+            ), default=0
+        ) : Or(float, int),
+        Optional(
+            Literal(
+                'charge_integration_t_wait',
+                description='Settling time before and between ramp edges used by the ' \
+                            'charge_integration input-capacitance procedure. Must be long ' \
+                            'enough for the output isolation network (R_on x C_out) to reach ' \
+                            'steady state before the integration ramp begins. ' \
+                            'Unit is specified by ``settings.units.time``. Default 0 means ' \
+                            'automatically set to 1000 x charge_integration_t_slew.'
+            ), default=0
+        ) : Or(float, int),
+        Optional(
+            Literal(
                 'metastability_constraint_search_tolerance',
                 description='Tolerance used during setup/hold constraint search. Unit is ' \
                             'specified by ``settings.units.time``.'

--- a/charlib/config/syntax.py
+++ b/charlib/config/syntax.py
@@ -222,10 +222,11 @@ class ConfigFile:
             Optional(
                 Literal(
                     'input_capacitance_procedure',
-                    description='The name of a procedure used to measure the capacitance of ' \
-                                'each input pin for each cell.' # TODO: Refer to docs for procedures
+                    description='The name of a procedure used to measure the capacitance of '
+                                'each input pin for each cell. '
+                                'Options: "ac_sweep" (default) or "qv_method".'
                 ), default='ac_sweep'
-            ) : str,
+            ) : Or('ac_sweep', 'qv_method'),
             Optional(
                 Literal(
                     'combinational_delay_procedure',

--- a/charlib/config/syntax.py
+++ b/charlib/config/syntax.py
@@ -224,9 +224,9 @@ class ConfigFile:
                     'input_capacitance_procedure',
                     description='The name of a procedure used to measure the capacitance of '
                                 'each input pin for each cell. '
-                                'Options: "ac_sweep" (default) or "qv_method".'
+                                'Options: "ac_sweep" (default) or "charge_integration".'
                 ), default='ac_sweep'
-            ) : Or('ac_sweep', 'qv_method'),
+            ) : Or('ac_sweep', 'charge_integration'),
             Optional(
                 Literal(
                     'combinational_delay_procedure',


### PR DESCRIPTION
New Q/V method procedure for pin capacitance. The default is to use the ac-sweep but can be toggled in the YAML with the new key under `Simulation: input_capacitance_procedure:` (`ac_sweep` or `qv_method`).

The procedure uses estimates for simulation time that may not work for all cells. In the future these parameters should be made more configurable and be more intelligently determined.