### PR TITLE
Fix Liberty group IDs

### DIFF
--- a/charlib/liberty/liberty.py
+++ b/charlib/liberty/liberty.py
@@ -65,15 +65,14 @@ class Group(Statement):
     def unique_key(self):
         # overrides for groups which are not uniquely identifiable by group name and identifier
         if self.name == 'timing' and self.attributes.get('related_pin') and self.attributes.get('timing_type'):
-            return (
-                self.name,
-                self.attributes.get('related_pin'),
-                self.attributes.get('timing_type')
-            )
+            return (self.name, self.attributes.get('related_pin').value,
+                    self.attributes.get('timing_type').value)
+        elif self.name == 'leakage_power' and self.attributes.get('when'):
+            return (self.name, self.attributes.get('when').value)
         return super().unique_key
 
     def add_group(self, group, group_id=''):
-        """Add a sub-group.
+        """Add a subgroup.
 
         :param group: An existing Group object or the name of the group to create.
         :param group_id: The group identifier for the new group. Ignored if group is a Group object.
@@ -81,19 +80,37 @@ class Group(Statement):
         if not isinstance(group, Group):
             group = Group(group, group_id)
         try:
-            existing_group = self.group(group.name, group.identifier)
+            existing_group = self.groups[group.unique_key]
             group.merge(existing_group)
         except KeyError:
             pass
         finally:
             self.groups[group.unique_key] = group
 
-    def group(self, *key):
-        """Look up a sub-group by key, such as name and id. Note that order matters for key args."""
+    def group(self, name, identifier='', **attributes):
+        """Look up a subgroup by name and id
+
+        This method is primarily a convenience function for self.groups[(name, id)]. If the initial
+        (name, id) lookup fails and attrs are present, an attempt is made to find a unique subgroup
+        by checking attributes as well. This method will not return subgroups of subgroups; see
+        filter_subgroups if you need that behavior.
+
+        :param name: The subgroup name (i.e. 'timing' of 'cell')
+        :param identifier: (Optional) The subgroup identifier. Ignored if not specified.
+        :param **attributes: (Optional) Name-value pairs corresponding to subgroup attributes.
+        :raises KeyError: If unable to find a unique matching group.
+        """
         try:
-            return self.groups[key]
+            return self.groups[(name, identifier)]
         except KeyError as e:
-            raise KeyError(key) from e
+            if attributes: # Fall back to subgroup search
+                groups = self.filter_subgroups(name, identifier, **attributes)
+                groups = [g for g in groups  if g.unique_key in self.groups]
+                if len(groups) != 1:
+                    raise KeyError(f'Subgroup search found {len(groups)} matching groups!') from e
+                return groups[0]
+            else:
+                raise
 
     def subgroups_with_name(self, name: str):
         """Yield subgroups with the specified name.
@@ -106,16 +123,21 @@ class Group(Statement):
             elif group.groups:
                 yield from group.subgroups_with_name(name)
 
-    def subgroups_with_identifier(self, identifier: str):
-        """Yield subgroups with the specified identifier.
+    def filter_subgroups(self, name: str, identifier='', **attributes):
+        """Yield subgroups with the specified name, id, and matching attributes
 
-        :param identifier: The subgroup identifier to search for.
+        :param name: The subgroup name (i.e. 'timing' or 'cell') to search for.
+        :param identifier: (Optional) The subgroup identifier to search for. Ignored if not
+                           specified.
+        :param **attributes: (Optional) Name-value pairs corresponding to subgroup attributes
+                             to match.
         """
-        for group in self.groups.values():
-            if group.identifier == identifier:
-                yield group
-            elif group.groups:
-                yield from group.subgroups_with_identifier(identifier)
+        for group in self.subgroups_with_name(name):
+            if identifier and not group.identifier == identifier:
+                continue
+            if any([(group.attributes.get(k) != k,v) for k,v in attributes.items()]):
+                continue
+            yield group
 
     def add_attribute(self, attr: str, value=None, precision=None):
         """Add a simple or complex attribute.
@@ -179,7 +201,12 @@ class Attribute(Statement):
 
     def __eq__(self, other):
         # Implements == operation
-        return self.name == other.name and self.value == other.value
+        if isinstance(other, Attribute):
+            return self.name == other.name and self.value == other.value
+        elif isinstance(other, tuple) and len(other) == 2:
+            return (self.name, self.value) == other
+        else:
+            return NotImplemented
 
     def __repr__(self):
         # Display for debugging

--- a/charlib/liberty/liberty.py
+++ b/charlib/liberty/liberty.py
@@ -42,7 +42,8 @@ class Group(Statement):
                 # Rekeying value collided with an existing sibling. Rather than raising, merge
                 # the sibling into value, since both represent the same logical subgroup.
                 del self.data[new_key]
-                value.merge(existing_group)
+                existing_group.merge(value)
+                value = existing_group
                 new_key = value.unique_key
             if key in self.data and key != new_key:
                 del self.data[key]
@@ -287,7 +288,8 @@ class Attribute(Statement):
 class Define(Attribute):
     """A define is basically a complex attribute with a bit more input validation"""
     def __init__(self, attribute_name, group_name, attribute_type):
-        # TODO: validate attribute_type: must be one of 'Boolean', 'string', 'integer', or 'floating point'
+        if attribute_type not in ['Boolean', 'string', 'integer', 'float']:
+            raise ValueError("attribute_type must be one of 'Boolean', 'string', 'integer', or 'float'")
         super.__init__('define', [attribute_name, group_name, attribute_type])
 
 

--- a/charlib/liberty/liberty.py
+++ b/charlib/liberty/liberty.py
@@ -32,8 +32,8 @@ class Group(Statement):
         """Custom dictionary with auto-updating keys. Used for keeping track of subgroups."""
 
         def __setitem__(self, key, value):
-            self._update_key(key, value)
-            value._bind_to_parent_group(self)
+            survivor = self._update_key(key, value)
+            survivor._bind_to_parent_group(self)
 
         def _update_key(self, key, value):
             new_key = value.unique_key
@@ -48,6 +48,7 @@ class Group(Statement):
             if key in self.data and key != new_key:
                 del self.data[key]
             self.data[new_key] = value
+            return value
 
     def __init__(self, group_name: str, group_id: str=''):
         """Create a new Liberty group.
@@ -290,7 +291,7 @@ class Define(Attribute):
     def __init__(self, attribute_name, group_name, attribute_type):
         if attribute_type not in ['Boolean', 'string', 'integer', 'float']:
             raise ValueError("attribute_type must be one of 'Boolean', 'string', 'integer', or 'float'")
-        super.__init__('define', [attribute_name, group_name, attribute_type])
+        super().__init__('define', [attribute_name, group_name, attribute_type])
 
 
 if __name__ == "__main__":

--- a/charlib/liberty/liberty.py
+++ b/charlib/liberty/liberty.py
@@ -36,6 +36,9 @@ class Group(Statement):
             value._bind_to_parent_group(self)
 
         def _update_key(self, key, value):
+            existing_group = self.data.get(value.unique_key)
+            if existing_group and existing_group is not value:
+                raise ValueError(f'Duplicate subgroup with key {value.unique_key}')
             if key in self.data and key != value.unique_key:
                 del self.data[key]
             self.data[value.unique_key] = value

--- a/charlib/liberty/liberty.py
+++ b/charlib/liberty/liberty.py
@@ -36,12 +36,17 @@ class Group(Statement):
             value._bind_to_parent_group(self)
 
         def _update_key(self, key, value):
-            existing_group = self.data.get(value.unique_key)
+            new_key = value.unique_key
+            existing_group = self.data.get(new_key)
             if existing_group and existing_group is not value:
-                raise ValueError(f'Duplicate subgroup with key {value.unique_key}')
-            if key in self.data and key != value.unique_key:
+                # Rekeying value collided with an existing sibling. Rather than raising, merge
+                # the sibling into value, since both represent the same logical subgroup.
+                del self.data[new_key]
+                value.merge(existing_group)
+                new_key = value.unique_key
+            if key in self.data and key != new_key:
                 del self.data[key]
-            self.data[value.unique_key] = value
+            self.data[new_key] = value
 
     def __init__(self, group_name: str, group_id: str=''):
         """Create a new Liberty group.

--- a/charlib/liberty/liberty.py
+++ b/charlib/liberty/liberty.py
@@ -128,7 +128,7 @@ class Group(Statement):
         except KeyError as e:
             if attributes: # Fall back to subgroup search
                 groups = self.filter_subgroups(name, identifier, **attributes)
-                groups = [g for g in groups  if g.unique_key in self.groups]
+                groups = [g for g in groups if self.groups.get(g.unique_key) is g]
                 if len(groups) != 1:
                     raise KeyError(f'Subgroup search found {len(groups)} matching groups!') from e
                 return groups[0]
@@ -175,6 +175,7 @@ class Group(Statement):
             self.attributes[attr.name] = attr
         else:
             self.attributes[attr] = Attribute(attr, value, precision)
+        # If this is a subgroup, updating attributes may have changed this group's key
         if self._parent_dict:
             self._parent_dict._update_key(old_key, self)
 

--- a/charlib/liberty/liberty.py
+++ b/charlib/liberty/liberty.py
@@ -16,6 +16,10 @@ class Statement:
             raise ValueError('Liberty object names must consist of only alphanumeric characters and underscores!')
         self._name = name
 
+    @property
+    def unique_key(self):
+        return (self.name, self.identifier)
+
     def to_liberty(self, indent=0, precision=6):
         return NotImplemented
 
@@ -37,15 +41,14 @@ class Group(Statement):
         self.groups = dict()
         self.attributes = dict()
 
-    def __hash__(self):
-        # Implements hash(Group)
-        return hash((self.name, self.identifier))
-
     def __eq__(self, other):
         # Implements == operation
         if not isinstance(other, Group):
             return NotImplemented
-        return hash(self) == hash(other) and self.groups == other.groups and self.attributes == other.attributes
+        return self.name == other.name \
+            and self.identifier == other.identifier \
+            and self.groups == other.groups \
+            and self.attributes == other.attributes
 
     def __iadd__(self, other):
         # In-place add. Implements += operation
@@ -57,6 +60,17 @@ class Group(Statement):
     def __repr__(self):
         # Display for debugging
         return f'Group({self.name}, {self.identifier})'
+
+    @property
+    def unique_key(self):
+        # overrides for groups which are not uniquely identifiable by group name and identifier
+        if self.name == 'timing' and self.attributes.get('related_pin') and self.attributes.get('timing_type'):
+            return (
+                self.name,
+                self.attributes.get('related_pin'),
+                self.attributes.get('timing_type')
+            )
+        return super().unique_key
 
     def add_group(self, group, group_id=''):
         """Add a sub-group.
@@ -72,15 +86,14 @@ class Group(Statement):
         except KeyError:
             pass
         finally:
-            self.groups[hash(group)] = group
+            self.groups[group.unique_key] = group
 
-    def group(self, name, identifier=''):
-        """Look up a sub-group by name and id"""
+    def group(self, *key):
+        """Look up a sub-group by key, such as name and id. Note that order matters for key args."""
         try:
-            return self.groups[hash((name, identifier))]
+            return self.groups[key]
         except KeyError as e:
-            # Use the non-hashed key in error display
-            raise KeyError((name, identifier)) from e
+            raise KeyError(key) from e
 
     def subgroups_with_name(self, name: str):
         """Yield subgroups with the specified name.
@@ -121,8 +134,8 @@ class Group(Statement):
         """Merge another group into this one, merging sub-groups and adding attributes.
 
         Note that attribute values from other will override attribute values from self."""
-        if not hash(self) == hash(other):
-            raise ValueError("Group name and id must match in order to merge!")
+        if not self.unique_key == other.unique_key:
+            raise ValueError(f'Cannot merge groups with different identifiers {self.unique_key} and {other.unique_key}')
         [self.add_group(group) for group in other.groups.values()]
         self.attributes |= other.attributes
 
@@ -163,10 +176,6 @@ class Attribute(Statement):
         # TODO: Validate attribute_value
         self.value = attribute_value
         self.precision = precision
-
-    def __hash__(self):
-        # Implements hash(Attribute)
-        return hash((self.name, *list(self.value)))
 
     def __eq__(self, other):
         # Implements == operation

--- a/charlib/liberty/liberty.py
+++ b/charlib/liberty/liberty.py
@@ -1,8 +1,10 @@
 """Tools for creating Liberty groups. See Liberty User Guide Vol 1, Chapter 1."""
 
 import re
+from collections import UserDict
 
 INDENT_STR = '  '
+
 
 class Statement:
     """Abstract base class for Liberty statements, such as Groups and Attributes"""
@@ -25,6 +27,19 @@ class Statement:
 
 
 class Group(Statement):
+
+    class SubGroupDict(UserDict):
+        """Custom dictionary with auto-updating keys. Used for keeping track of subgroups."""
+
+        def __setitem__(self, key, value):
+            self._update_key(key, value)
+            value._bind_to_parent_group(self)
+
+        def _update_key(self, key, value):
+            if key in self.data and key != value.unique_key:
+                del self.data[key]
+            self.data[value.unique_key] = value
+
     def __init__(self, group_name: str, group_id: str=''):
         """Create a new Liberty group.
 
@@ -38,8 +53,12 @@ class Group(Statement):
         """
         self.name = group_name
         self.identifier = group_id # TODO: Validate
-        self.groups = dict()
+        self.groups = self.SubGroupDict()
         self.attributes = dict()
+        self._parent_dict = None
+
+    def _bind_to_parent_group(self, parent_group_dict):
+        self._parent_dict = parent_group_dict
 
     def __eq__(self, other):
         # Implements == operation
@@ -136,7 +155,7 @@ class Group(Statement):
         for group in self.subgroups_with_name(name):
             if identifier and group.identifier != identifier:
                 continue
-            if any([group.attributes.get(k) != (k,v) for k,v in attributes.items()]):
+            if any(group.attributes.get(k) != (k,v) for k,v in attributes.items()):
                 continue
             yield group
 
@@ -148,19 +167,25 @@ class Group(Statement):
         :param precision: If different from default, the number of digits to display when printed.
                           Ignored if attr is an Attribute object.
         """
+        old_key = self.unique_key
         if isinstance(attr, Attribute):
             self.attributes[attr.name] = attr
         else:
             self.attributes[attr] = Attribute(attr, value, precision)
+        if self._parent_dict:
+            self._parent_dict._update_key(old_key, self)
 
     def merge(self, other):
         """Merge another group into this one, merging sub-groups and adding attributes.
 
         Note that attribute values from other will override attribute values from self."""
+        old_key = self.unique_key
         if not self.unique_key == other.unique_key:
             raise ValueError(f'Cannot merge groups with different identifiers {self.unique_key} and {other.unique_key}')
         [self.add_group(group) for group in other.groups.values()]
         self.attributes |= other.attributes
+        if self._parent_dict:
+            self._parent_dict._update_key(old_key, self)
 
     def to_liberty(self, indent_level=0, precision=1, **kwargs):
         """Convert this group to a Liberty-format string

--- a/charlib/liberty/liberty.py
+++ b/charlib/liberty/liberty.py
@@ -81,7 +81,8 @@ class Group(Statement):
             group = Group(group, group_id)
         try:
             existing_group = self.groups[group.unique_key]
-            group.merge(existing_group)
+            existing_group.merge(group)
+            group = existing_group
         except KeyError:
             pass
         finally:
@@ -133,9 +134,9 @@ class Group(Statement):
                              to match.
         """
         for group in self.subgroups_with_name(name):
-            if identifier and not group.identifier == identifier:
+            if identifier and group.identifier != identifier:
                 continue
-            if any([(group.attributes.get(k) != k,v) for k,v in attributes.items()]):
+            if any([group.attributes.get(k) != (k,v) for k,v in attributes.items()]):
                 continue
             yield group
 

--- a/test/logic/test_liberty.py
+++ b/test/logic/test_liberty.py
@@ -1,0 +1,65 @@
+from charlib.liberty import liberty
+
+
+# ---------------------------------------------------------------------------
+# Group.merge / rekey collision tests
+# ---------------------------------------------------------------------------
+
+def test_merge_rekey_collision_merges_into_existing_sibling():
+    """Merging two parents whose timing subgroups only partially specify
+    related_pin/timing_type can cause a subgroup's unique_key to change to
+    match an already-present sibling once merged. This should merge the two
+    subgroups together instead of raising a Duplicate subgroup ValueError."""
+    cell = liberty.Group('cell', 'inv')
+
+    # A sibling that already has the fully-qualified key.
+    existing = liberty.Group('timing', '')
+    existing.add_attribute('related_pin', 'X')
+    existing.add_attribute('timing_type', 'combinational_rise')
+    existing.add_attribute('marker', 'existing')
+    cell.add_group(existing)
+
+    # A timing group that only has related_pin so far; its key is still ('timing', '').
+    partial = liberty.Group('timing', '')
+    partial.add_attribute('related_pin', 'X')
+    cell.add_group(partial)
+
+    # A separate cell with a timing group that only has timing_type; merging this
+    # into `cell` will complete `partial`'s key, colliding with `existing`.
+    other_cell = liberty.Group('cell', 'inv')
+    other = liberty.Group('timing', '')
+    other.add_attribute('timing_type', 'combinational_rise')
+    other_cell.add_group(other)
+
+    cell.merge(other_cell)
+
+    timing_groups = [g for g in cell.groups.values() if g.name == 'timing']
+    assert len(timing_groups) == 1
+    merged = timing_groups[0]
+    assert merged.attributes['related_pin'] == ('related_pin', 'X')
+    assert merged.attributes['timing_type'] == ('timing_type', 'combinational_rise')
+    assert merged.attributes['marker'] == ('marker', 'existing')
+
+
+def test_add_attribute_rekey_collision_merges_into_existing_sibling():
+    """Adding an attribute directly to a bound subgroup can also change its
+    unique_key to collide with a sibling; this should merge rather than raise."""
+    cell = liberty.Group('cell', 'inv')
+
+    existing = liberty.Group('timing', '')
+    existing.add_attribute('related_pin', 'X')
+    existing.add_attribute('timing_type', 'combinational_rise')
+    existing.add_attribute('marker', 'existing')
+    cell.add_group(existing)
+
+    partial = liberty.Group('timing', '')
+    partial.add_attribute('related_pin', 'X')
+    cell.add_group(partial)
+
+    # Directly completing partial's key should merge it with `existing`.
+    partial.add_attribute('timing_type', 'combinational_rise')
+
+    timing_groups = [g for g in cell.groups.values() if g.name == 'timing']
+    assert len(timing_groups) == 1
+    merged = timing_groups[0]
+    assert merged.attributes['marker'] == ('marker', 'existing')

--- a/test/logic/test_liberty.py
+++ b/test/logic/test_liberty.py
@@ -16,12 +16,14 @@ def test_merge_rekey_collision_merges_into_existing_sibling():
     existing = liberty.Group('timing', '')
     existing.add_attribute('related_pin', 'X')
     existing.add_attribute('timing_type', 'combinational_rise')
-    existing.add_attribute('marker', 'existing')
+    existing.add_attribute('marker', 'existing') # This key should remain in the final merged group
+    existing.add_attribute('time', "11:59") # This key will be conflicted and should be overwritten
     cell.add_group(existing)
 
     # A timing group that only has related_pin so far; its key is still ('timing', '').
     partial = liberty.Group('timing', '')
     partial.add_attribute('related_pin', 'X')
+    partial.add_attribute('time', "12:00") # Create conflict with existing to test which attr wins
     cell.add_group(partial)
 
     # A separate cell with a timing group that only has timing_type; merging this
@@ -39,6 +41,7 @@ def test_merge_rekey_collision_merges_into_existing_sibling():
     assert merged.attributes['related_pin'] == ('related_pin', 'X')
     assert merged.attributes['timing_type'] == ('timing_type', 'combinational_rise')
     assert merged.attributes['marker'] == ('marker', 'existing')
+    assert merged.attributes['time'] == ('time', '12:00')
 
 
 def test_add_attribute_rekey_collision_merges_into_existing_sibling():
@@ -50,10 +53,12 @@ def test_add_attribute_rekey_collision_merges_into_existing_sibling():
     existing.add_attribute('related_pin', 'X')
     existing.add_attribute('timing_type', 'combinational_rise')
     existing.add_attribute('marker', 'existing')
+    existing.add_attribute('time', "11:59") # This key will be conflicted and should be overwritten
     cell.add_group(existing)
 
     partial = liberty.Group('timing', '')
     partial.add_attribute('related_pin', 'X')
+    partial.add_attribute('time', "12:00") # Create conflict with existing to test which attr wins
     cell.add_group(partial)
 
     # Directly completing partial's key should merge it with `existing`.
@@ -63,3 +68,4 @@ def test_add_attribute_rekey_collision_merges_into_existing_sibling():
     assert len(timing_groups) == 1
     merged = timing_groups[0]
     assert merged.attributes['marker'] == ('marker', 'existing')
+    assert merged.attributes['time'] == ('time', '12:00')


### PR DESCRIPTION
Resolves #110

## Summary

- Remove all uses of `hash()` for liberty group lookup, resulting in groups that work with Python's cross-session hash randomization.
- Improve identity and equality behavior for more consistent comparisons and merges on all liberty classes.
- Enhanced subgroup lookup supporting attribute-based filtering when (name, identifier) are insufficient.
- Add automatic rekeying for subgroup dictionaries to keep lookup fast.
- Allow Attribute to check equality against `(name, value)` 2-tuples.