### PR TITLE
Extract operating point analysis function to utils.py

### DIFF
--- a/charlib/characterizer/procedures/combinational/leakage_power.py
+++ b/charlib/characterizer/procedures/combinational/leakage_power.py
@@ -2,6 +2,7 @@ import itertools
 import PySpice
 
 from charlib.characterizer import utils
+from charlib.characterizer.cell import Port
 from charlib.characterizer.procedures import register, ProcedureFailedException
 from charlib.liberty import liberty
 
@@ -40,12 +41,35 @@ def measure_leakage_for_state(cell, config, settings, state_map):
                f'with state {state_map}')
         raise ProcedureFailedException(msg) from e
 
-        # Branch current: ngspice names it <element_name>#branch, simplified to <element_name> (lower)
-        i_vdd = float(analysis.branches[settings.primary_power.name.lower()][0])
-        power_W = settings.primary_power.voltage * abs(i_vdd)
-        power_value = (power_W @ PySpice.Unit.u_W).convert(
-            settings.units.power.prefixed_unit
-        ).value
+    # Total static power = sum of signed V*I across every pin/rail that has its own
+    # source in the DC testbench built by operating_point_analysis
+    total_power_W = 0.0
+    for pin in cell.pins_in_netlist_order():
+        match pin.role:
+            case Port.Role.LOGIC if pin.name in cell.inputs:
+                voltage = settings.primary_power.voltage if state_map[pin.name] == '1' else 0.0
+                elem = pin.name
+            case Port.Role.POWER:
+                voltage, elem = settings.primary_power.voltage, settings.primary_power.subscript
+            case Port.Role.GROUND:
+                voltage, elem = settings.primary_ground.voltage, settings.primary_ground.subscript
+            case Port.Role.NWELL:
+                voltage, elem = settings.nwell.voltage, settings.nwell.subscript
+            case Port.Role.PWELL:
+                voltage, elem = settings.pwell.voltage, settings.pwell.subscript
+            case _:
+                continue
+        branch = f'v{elem}'.lower()
+        if branch not in analysis.branches:
+            continue
+        i_branch = float(analysis.branches[branch][0])
+        # By SPICE convention a voltage source's branch current is defined flowing INTO its
+        # positive terminal from the external circuit
+        total_power_W += voltage * (-i_branch)
+
+    power_value = (total_power_W @ PySpice.Unit.u_W).convert(
+        settings.units.power.prefixed_unit
+    ).value
 
     result = cell.liberty
     lp_group = liberty.Group('leakage_power')

--- a/charlib/characterizer/procedures/combinational/leakage_power.py
+++ b/charlib/characterizer/procedures/combinational/leakage_power.py
@@ -2,7 +2,6 @@ import itertools
 import PySpice
 
 from charlib.characterizer import utils
-from charlib.characterizer.cell import Port
 from charlib.characterizer.procedures import register, ProcedureFailedException
 from charlib.liberty import liberty
 
@@ -33,55 +32,13 @@ def measure_leakage_for_state(cell, config, settings, state_map):
     :param settings: CharacterizationSettings with library-wide config.
     :param state_map: dict mapping each logic input name to '0' or '1'.
     """
-    circuit = utils.init_circuit(
-        'leakage', cell.netlist, config.models, settings.named_nodes, settings.units
-    )
-
-    connections = []
-    for pin in cell.pins_in_netlist_order():
-        match pin.role:
-            case Port.Role.LOGIC:
-                connections.append(f'v{pin.name}')
-                if pin.name in cell.inputs:
-                    v = settings.primary_power.voltage if state_map[pin.name] == '1' else 0
-                    circuit.V(pin.name, f'v{pin.name}', circuit.gnd, v * settings.units.voltage)
-                # outputs: node named v{pin.name}, driven to DC rail by the cell, no load
-            case Port.Role.POWER:
-                connections.append(settings.primary_power.name)
-            case Port.Role.GROUND:
-                connections.append(settings.primary_ground.name)
-            case Port.Role.NWELL:
-                connections.append(settings.nwell.name)
-            case Port.Role.PWELL:
-                connections.append(settings.pwell.name)
-            case _:
-                raise ValueError(f'Unable to connect unrecognized pin {pin.name} in cell {cell.name}')
-    circuit.X('dut', cell.name, *connections)
-
-    simulator = PySpice.Simulator.factory(simulator=settings.simulation.backend)
-    simulation = simulator.simulation(
-        circuit,
-        temperature=settings.temperature,
-        nominal_temperature=settings.temperature
-    )
-    simulation.operating_point()
-
-    if settings.debug:
-        debug_path = settings.debug_dir / cell.name / __name__.split('.')[-1]
-        debug_path.mkdir(parents=True, exist_ok=True)
-        with open(debug_path / f'state = {state_map}.sp', 'w', encoding='utf-8') as f:
-            f.write(str(simulation))
-
-    if settings.dry_run:
-        # TODO: Display a message if not settings.quiet
-        power_value = -1
-    else:
-        try:
-            analysis = simulator.run(simulation)
-        except Exception as e:
-            msg = (f'Procedure measure_leakage_for_state failed for cell {cell.name} '
-                   f'with state {state_map}')
-            raise ProcedureFailedException(msg) from e
+    debug_path = (settings.debug_dir / cell.name / __name__.split('.')[-1]) if settings.debug else None
+    try:
+        analysis = utils.operating_point_analysis(cell, config, settings, state_map, debug_path=debug_path)
+    except Exception as e:
+        msg = (f'Procedure measure_leakage_for_state failed for cell {cell.name} '
+               f'with state {state_map}')
+        raise ProcedureFailedException(msg) from e
 
         # Branch current: ngspice names it <element_name>#branch, simplified to <element_name> (lower)
         i_vdd = float(analysis.branches[settings.primary_power.name.lower()][0])

--- a/charlib/characterizer/utils.py
+++ b/charlib/characterizer/utils.py
@@ -6,6 +6,8 @@ import math
 import PySpice
 import numpy as np
 
+from charlib.characterizer.port import Port
+
 
 class PinStateMap:
     """Connect ports of a cell to the appropriate waveforms for a test.
@@ -90,6 +92,65 @@ def init_circuit(title, cell_netlist, models, supplies, units):
         if supply.name.upper() not in ['GND', '0']:
             circuit.V(supply.subscript, supply.name, circuit.gnd, supply.voltage*units.voltage)
     return circuit
+
+
+def operating_point_analysis(cell, config, settings, state_map, debug_path=None):
+    """Build and run a DC operating point for the given input state.
+
+    Returns the PySpice analysis object, giving callers access to all branch currents
+    and node voltages. If debug_path is provided and the simulation fails, the SPICE
+    netlist is written there before re-raising.
+
+    :param cell: Cell object under test.
+    :param config: CellTestConfig with model paths.
+    :param settings: CharacterizationSettings with library-wide config.
+    :param state_map: dict mapping each input pin name to '0' or '1'.
+    :param debug_path: Optional Path; if given, SPICE file is written here on failure.
+    """
+    circuit = init_circuit('dc_op', cell.netlist, config.models, settings.named_nodes,
+                           settings.units)
+
+    connections = []
+    for pin in cell.pins_in_netlist_order():
+        match pin.role:
+            case Port.Role.LOGIC:
+                connections.append(f'v{pin.name}')
+                if pin.name in cell.inputs:
+                    v = settings.primary_power.voltage if state_map[pin.name] == '1' else 0
+                    circuit.V(pin.name, f'v{pin.name}', circuit.gnd, v * settings.units.voltage)
+            case Port.Role.POWER:
+                connections.append(settings.primary_power.name)
+            case Port.Role.GROUND:
+                connections.append(settings.primary_ground.name)
+            case Port.Role.NWELL:
+                connections.append(settings.nwell.name)
+            case Port.Role.PWELL:
+                connections.append(settings.pwell.name)
+            case _:
+                raise ValueError(
+                    f'Unable to connect unrecognized pin {pin.name} in cell {cell.name}')
+    circuit.X('dut', cell.name, *connections)
+
+    simulator = PySpice.Simulator.factory(simulator=settings.simulation.backend)
+    simulation = simulator.simulation(
+        circuit,
+        temperature=settings.temperature,
+        nominal_temperature=settings.temperature
+    )
+    simulation.options('nopage', 'nomod')
+    simulation.operating_point()
+
+    try:
+        analysis = simulator.run(simulation)
+    except Exception:
+        if debug_path is not None:
+            debug_path.mkdir(parents=True, exist_ok=True)
+            with open(debug_path / f'state = {state_map}.sp', 'w', encoding='utf-8') as f:
+                f.write(str(simulation))
+        raise
+
+    return analysis
+
 
 def find_min_valid(probe_fn, start, step, tolerance, max_exp=1000):
     """Find the minimum x such that probe_fn(x) is not NaN.


### PR DESCRIPTION
Extracts the operating point analysis functionality from leakage_power.py to a utils.py function. leakage_power.py now uses the utils function and calculates leakage power as the sum of static V*I for every pin/rail that has its own source in the DC testbench.